### PR TITLE
FlaggedEnum::accepts should not throw any exception

### DIFF
--- a/src/FlaggedEnum.php
+++ b/src/FlaggedEnum.php
@@ -29,7 +29,7 @@ abstract class FlaggedEnum extends ReadableEnum
     public static function accepts($value): bool
     {
         if (!is_int($value)) {
-            throw new InvalidValueException($value, static::class);
+            return false;
         }
 
         if ($value === self::NONE) {

--- a/tests/Unit/FlaggedEnumTest.php
+++ b/tests/Unit/FlaggedEnumTest.php
@@ -19,9 +19,9 @@ class FlaggedEnumTest extends \PHPUnit_Framework_TestCase
      * @expectedException \Elao\Enum\Exception\InvalidValueException
      * @expectedExceptionMessage "1" is not an acceptable value
      */
-    public function testThrowExceptionWhenValueIsNotInteger()
+    public function testGetThrowExceptionWhenValueIsNotInteger()
     {
-        Permissions::accepts('1');
+        Permissions::get('1');
     }
 
     public function acceptableValueProvider()
@@ -34,6 +34,7 @@ class FlaggedEnumTest extends \PHPUnit_Framework_TestCase
             [Permissions::READ | Permissions::WRITE, true],
             [Permissions::ALL, true],
             [99, false],
+            ['4', false],
         ];
     }
 


### PR DESCRIPTION
`FlaggedEnum::accepts` should not throw any exception as it's not part of the `EnumInterface` contract. Even if the provided type is invalid. Simply return `false`. (`get` will throw the exception)