### PR TITLE
Add Symfony Validator Enum constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,8 @@ To use the constraint, simply provide the enum `class`:
 # src/AppBundle/Resources/config/validation.yml
 AppBundle\Entity\User:
     properties:
-        gender: MyApp\Enum\Gender
+        gender:
+            - Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum: MyApp\Enum\Gender
 ```
 
 If the property value is not an enum instance, set the `asValue` option to true in order to simply validate the enum value:
@@ -606,9 +607,10 @@ If the property value is not an enum instance, set the `asValue` option to true 
 # src/AppBundle/Resources/config/validation.yml
 AppBundle\Entity\User:
     properties:
-        gender: 
-            class: MyApp\Enum\Gender
-            asValue: true
+        gender:
+            - Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum:
+                class: MyApp\Enum\Gender
+                asValue: true
 ```
 
 You can restrict the available choices by setting the allowed values in the `choices` option:
@@ -617,11 +619,12 @@ You can restrict the available choices by setting the allowed values in the `cho
 # src/AppBundle/Resources/config/validation.yml
 AppBundle\Entity\User:
     properties:
-        gender: 
-            class: MyApp\Enum\Gender
-            choices: 
-              - female
-              - !php/const:MyApp\Enum\Gender::MALE # You can use PHP constants with the YAML format since Symfony 3.2
+        gender:
+            - Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum:
+                class: MyApp\Enum\Gender
+                choices: 
+                    - female
+                    - !php/const:MyApp\Enum\Gender::MALE # You can use PHP constants with the YAML format since Symfony 3.2
 ```
 
 The `choice` option only accepts enum values and normalize it internally to enum instances if `asValue` is `false`.
@@ -632,9 +635,10 @@ You can also use a [`callback`](http://symfony.com/doc/current/reference/constra
 # src/AppBundle/Resources/config/validation.yml
 AppBundle\Entity\User:
     properties:
-        gender: 
-            class: MyApp\Enum\Gender
-            callback: ['allowedValues']
+        gender:
+            - Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum:
+                class: MyApp\Enum\Gender
+                callback: ['allowedValues']
 ```
 
 Where `allowedValues` is a static method of `MyApp\Enum\Gender`, returning allowed instances (:warning: should return values if `asValue` is set to `true`).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Table of Contents
     * [Symfony Form component](#symfony-form-component)
       * [Simple enums](#simple-enums)
       * [Flagged enums](#flagged-enums-1)
+    * [Symfony Validator component](#symfony-validator-component)
   * [API](#api)
     * [Simple enum](#simple-enum)
     * [Readable enum](#readable-enum)
@@ -87,6 +88,7 @@ Providing our own package inspired from the best ones, on which we'll apply our 
 - Base implementation for simple, readable and flagged (bitmask) enumerations based on the [BiplaneEnumBundle](https://github.com/yethee/BiplaneEnumBundle) ones.
 - Symfony Form component integration with form types.
 - Symfony Serializer component integration with a normalizer class.
+- Symfony Validator component integration with an enum constraint.
 - Doctrine DBAL integration with abstract classes in order to persist your enumeration in database.
 
 # Installation
@@ -583,6 +585,61 @@ $form->get('permissions')->getData(); // Will return a single `Permissions` inst
 ```
 
 Same options are available, but on the contrary of the `EnumType`, the `multiple` option is always `true` and cannot be set to `false` (You'll always get a single enum instance though).
+
+## Symfony Validator component
+<a href="https://symfony.com"><img src="https://img.shields.io/badge/Symfony-%202.8%2F3.1%2B-green.svg?style=flat-square" title="Available for Symfony 2.8 and 3.1+" alt="Available for Symfony 2.8 and 3.1+" align="right"></a>
+
+The library provides a `Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum` constraint which makes use of Symfony's built-in [`Choice` constraint](http://symfony.com/doc/current/reference/constraints/Choice.html) and validator internally.
+
+To use the constraint, simply provide the enum `class`:
+
+```yaml
+# src/AppBundle/Resources/config/validation.yml
+AppBundle\Entity\User:
+    properties:
+        gender: MyApp\Enum\Gender
+```
+
+If the property value is not an enum instance, set the `asValue` option to true in order to simply validate the enum value:
+
+```yaml
+# src/AppBundle/Resources/config/validation.yml
+AppBundle\Entity\User:
+    properties:
+        gender: 
+            class: MyApp\Enum\Gender
+            asValue: true
+```
+
+You can restrict the available choices by setting the allowed values in the `choices` option:
+
+```yaml
+# src/AppBundle/Resources/config/validation.yml
+AppBundle\Entity\User:
+    properties:
+        gender: 
+            class: MyApp\Enum\Gender
+            choices: 
+              - female
+              - !php/const:MyApp\Enum\Gender::MALE # You can use PHP constants with the YAML format since Symfony 3.2
+```
+
+The `choice` option only accepts enum values and normalize it internally to enum instances if `asValue` is `false`.
+
+You can also use a [`callback`](http://symfony.com/doc/current/reference/constraints/Choice.html#callback):
+
+```yaml
+# src/AppBundle/Resources/config/validation.yml
+AppBundle\Entity\User:
+    properties:
+        gender: 
+            class: MyApp\Enum\Gender
+            callback: ['allowedValues']
+```
+
+Where `allowedValues` is a static method of `MyApp\Enum\Gender`, returning allowed instances (:warning: should return values if `asValue` is set to `true`).
+
+Any other [Choice option](http://symfony.com/doc/current/reference/constraints/Choice.html#available-options) (as `multiple`, `min`, ...) is available with the `Enum` constraint.
 
 # API
 

--- a/src/Bridge/Symfony/Validator/Constraint/Enum.php
+++ b/src/Bridge/Symfony/Validator/Constraint/Enum.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Symfony\Validator\Constraint;
+
+use Elao\Enum\EnumInterface;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\ChoiceValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+class Enum extends Choice
+{
+    /** @var string */
+    public $class;
+
+    /**
+     * Set to true in order to validate enum values instead of instances.
+     *
+     * @var bool
+     */
+    public $asValue = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($options)
+    {
+        parent::__construct($options);
+
+        $this->strict = true;
+
+        if (!is_a($this->class, EnumInterface::class, true)) {
+            throw new ConstraintDefinitionException(sprintf(
+                'The "class" option value must be a class FQCN implementing "%s". "%s" given.',
+                EnumInterface::class,
+                $this->class
+            ));
+        }
+
+        // Normalize choices
+        if (is_array($this->choices)) {
+            $choices = [];
+            foreach ($this->choices as $choiceValue) {
+                if (false === call_user_func([$this->class, 'accepts'], $choiceValue)) {
+                    throw new ConstraintDefinitionException(sprintf(
+                        'Choice %s is not a valid value for enum type "%s".',
+                        json_encode($choiceValue),
+                        $this->class
+                    ));
+                }
+
+                $choices[] = $this->asValue ? $choiceValue : call_user_func([$this->class, 'get'], $choiceValue);
+            }
+
+            $this->choices = $choices;
+        }
+
+        // only set the callback if no choice list set
+        if (!is_array($this->choices)) {
+            $this->callback = $this->asValue ? [$this->class, 'values'] : [$this->class, 'instances'];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return ChoiceValidator::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'class';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredOptions()
+    {
+        return ['class'];
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Validator/Constraint/ConstraintValidatorTestCase.php
+++ b/tests/Unit/Bridge/Symfony/Validator/Constraint/ConstraintValidatorTestCase.php
@@ -1,0 +1,349 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\PropertyMetadata;
+
+/**
+ * A test case to ease testing Constraint Validators.
+ *
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://github.com/symfony/symfony/blob/3.2/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+abstract class ConstraintValidatorTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ExecutionContextInterface
+     */
+    protected $context;
+
+    /**
+     * @var ConstraintValidatorInterface
+     */
+    protected $validator;
+
+    protected $group;
+    protected $metadata;
+    protected $object;
+    protected $value;
+    protected $root;
+    protected $propertyPath;
+    protected $constraint;
+    protected $defaultTimezone;
+
+    protected function setUp()
+    {
+        $this->group = 'MyGroup';
+        $this->metadata = null;
+        $this->object = null;
+        $this->value = 'InvalidValue';
+        $this->root = 'root';
+        $this->propertyPath = 'property.path';
+
+        // Initialize the context with some constraint so that we can
+        // successfully build a violation.
+        $this->constraint = new NotNull();
+
+        $this->context = $this->createContext();
+        $this->validator = $this->createValidator();
+        $this->validator->initialize($this->context);
+
+        \Locale::setDefault('en');
+
+        $this->setDefaultTimezone('UTC');
+    }
+
+    protected function tearDown()
+    {
+        $this->restoreDefaultTimezone();
+    }
+
+    protected function setDefaultTimezone($defaultTimezone)
+    {
+        // Make sure this method can not be called twice before calling
+        // also restoreDefaultTimezone()
+        if (null === $this->defaultTimezone) {
+            $this->defaultTimezone = date_default_timezone_get();
+            date_default_timezone_set($defaultTimezone);
+        }
+    }
+
+    protected function restoreDefaultTimezone()
+    {
+        if (null !== $this->defaultTimezone) {
+            date_default_timezone_set($this->defaultTimezone);
+            $this->defaultTimezone = null;
+        }
+    }
+
+    protected function createContext()
+    {
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')->getMock();
+        $contextualValidator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ContextualValidatorInterface')->getMock();
+
+        $context = new ExecutionContext($validator, $this->root, $translator);
+        $context->setGroup($this->group);
+        $context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+        $context->setConstraint($this->constraint);
+
+        $validator->expects($this->any())
+            ->method('inContext')
+            ->with($context)
+            ->will($this->returnValue($contextualValidator));
+
+        return $context;
+    }
+
+    protected function setGroup($group)
+    {
+        $this->group = $group;
+        $this->context->setGroup($group);
+    }
+
+    protected function setObject($object)
+    {
+        $this->object = $object;
+        $this->metadata = is_object($object)
+            ? new ClassMetadata(get_class($object))
+            : null;
+
+        $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+    }
+
+    protected function setProperty($object, $property)
+    {
+        $this->object = $object;
+        $this->metadata = is_object($object)
+            ? new PropertyMetadata(get_class($object), $property)
+            : null;
+
+        $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+    }
+
+    protected function setValue($value)
+    {
+        $this->value = $value;
+        $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+    }
+
+    protected function setRoot($root)
+    {
+        $this->root = $root;
+        $this->context = $this->createContext();
+        $this->validator->initialize($this->context);
+    }
+
+    protected function setPropertyPath($propertyPath)
+    {
+        $this->propertyPath = $propertyPath;
+        $this->context->setNode($this->value, $this->object, $this->metadata, $this->propertyPath);
+    }
+
+    protected function expectNoValidate()
+    {
+        $validator = $this->context->getValidator()->inContext($this->context);
+        $validator->expects($this->never())
+            ->method('atPath');
+        $validator->expects($this->never())
+            ->method('validate');
+    }
+
+    protected function expectValidateAt($i, $propertyPath, $value, $group)
+    {
+        $validator = $this->context->getValidator()->inContext($this->context);
+        $validator->expects($this->at(2 * $i))
+            ->method('atPath')
+            ->with($propertyPath)
+            ->will($this->returnValue($validator));
+        $validator->expects($this->at(2 * $i + 1))
+            ->method('validate')
+            ->with($value, $this->logicalOr(null, [], $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group);
+    }
+
+    protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group = null)
+    {
+        $contextualValidator = $this->context->getValidator()->inContext($this->context);
+        $contextualValidator->expects($this->at(2 * $i))
+            ->method('atPath')
+            ->with($propertyPath)
+            ->will($this->returnValue($contextualValidator));
+        $contextualValidator->expects($this->at(2 * $i + 1))
+            ->method('validate')
+            ->with($value, $constraints, $group);
+    }
+
+    protected function assertNoViolation()
+    {
+        $this->assertSame(0, $violationsCount = count($this->context->getViolations()), sprintf('0 violation expected. Got %u.', $violationsCount));
+    }
+
+    /**
+     * @param $message
+     *
+     * @return ConstraintViolationAssertion
+     */
+    protected function buildViolation($message)
+    {
+        return new ConstraintViolationAssertion($this->context, $message, $this->constraint);
+    }
+
+    abstract protected function createValidator();
+}
+
+/**
+ * @internal
+ */
+class ConstraintViolationAssertion
+{
+    /**
+     * @var ExecutionContextInterface
+     */
+    private $context;
+
+    /**
+     * @var ConstraintViolationAssertion[]
+     */
+    private $assertions;
+
+    private $message;
+    private $parameters = [];
+    private $invalidValue = 'InvalidValue';
+    private $propertyPath = 'property.path';
+    private $translationDomain;
+    private $plural;
+    private $code;
+    private $constraint;
+    private $cause;
+
+    public function __construct(ExecutionContextInterface $context, $message, Constraint $constraint = null, array $assertions = [])
+    {
+        $this->context = $context;
+        $this->message = $message;
+        $this->constraint = $constraint;
+        $this->assertions = $assertions;
+    }
+
+    public function atPath($path)
+    {
+        $this->propertyPath = $path;
+
+        return $this;
+    }
+
+    public function setParameter($key, $value)
+    {
+        $this->parameters[$key] = $value;
+
+        return $this;
+    }
+
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+    public function setTranslationDomain($translationDomain)
+    {
+        $this->translationDomain = $translationDomain;
+
+        return $this;
+    }
+
+    public function setInvalidValue($invalidValue)
+    {
+        $this->invalidValue = $invalidValue;
+
+        return $this;
+    }
+
+    public function setPlural($number)
+    {
+        $this->plural = $number;
+
+        return $this;
+    }
+
+    public function setCode($code)
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    public function setCause($cause)
+    {
+        $this->cause = $cause;
+
+        return $this;
+    }
+
+    public function buildNextViolation($message)
+    {
+        $assertions = $this->assertions;
+        $assertions[] = $this;
+
+        return new self($this->context, $message, $this->constraint, $assertions);
+    }
+
+    public function assertRaised()
+    {
+        $expected = [];
+        foreach ($this->assertions as $assertion) {
+            $expected[] = $assertion->getViolation();
+        }
+        $expected[] = $this->getViolation();
+
+        $violations = iterator_to_array($this->context->getViolations());
+
+        \PHPUnit_Framework_Assert::assertSame($expectedCount = count($expected), $violationsCount = count($violations), sprintf('%u violation(s) expected. Got %u.', $expectedCount, $violationsCount));
+
+        reset($violations);
+
+        foreach ($expected as $violation) {
+            \PHPUnit_Framework_Assert::assertEquals($violation, current($violations));
+            next($violations);
+        }
+    }
+
+    private function getViolation()
+    {
+        return new ConstraintViolation(
+            null,
+            $this->message,
+            $this->parameters,
+            $this->context->getRoot(),
+            $this->propertyPath,
+            $this->invalidValue,
+            $this->plural,
+            $this->code,
+            $this->constraint,
+            $this->cause
+        );
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Validator/Constraint/EnumTest.php
+++ b/tests/Unit/Bridge/Symfony/Validator/Constraint/EnumTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Validator\Constraint;
+
+use Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+
+class EnumTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultValueIsEnumClass()
+    {
+        $constraint = new Enum(SimpleEnum::class);
+
+        $this->assertSame(SimpleEnum::class, $constraint->class);
+    }
+
+    public function testNoChoicesSetsCallback()
+    {
+        $constraint = new Enum(SimpleEnum::class);
+
+        $this->assertSame([SimpleEnum::class, 'instances'], $constraint->callback);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "class" option value must be a class FQCN implementing "Elao\Enum\EnumInterface". "Foo" given.
+     */
+    public function testInvalidClassThrowsDefinitionException()
+    {
+        new Enum(\Foo::class);
+    }
+
+    public function testValidChoiceOption()
+    {
+        $constraint = new Enum(['class' => SimpleEnum::class, 'choices' => [
+            SimpleEnum::FIRST,
+            SimpleEnum::SECOND,
+        ]]);
+
+        $this->assertNull($constraint->callback);
+        $this->assertSame([
+            SimpleEnum::get(SimpleEnum::FIRST),
+            SimpleEnum::get(SimpleEnum::SECOND),
+        ], $constraint->choices);
+    }
+
+    public function testValidChoiceOptionAsValues()
+    {
+        $constraint = new Enum(['class' => SimpleEnum::class, 'asValue' => true, 'choices' => [
+            SimpleEnum::FIRST,
+            SimpleEnum::SECOND,
+        ]]);
+
+        $this->assertNull($constraint->callback);
+        $this->assertSame([SimpleEnum::FIRST, SimpleEnum::SECOND], $constraint->choices);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage Choice "bar" is not a valid value for enum type "Elao\Enum\Tests\Fixtures\Enum\SimpleEnum"
+     */
+    public function testInvalidChoiceOptionThrowsDefinitionException()
+    {
+        new Enum(['class' => SimpleEnum::class, 'choices' => ['bar']]);
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Validator/Constraint/EnumValidatorTest.php
+++ b/tests/Unit/Bridge/Symfony/Validator/Constraint/EnumValidatorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Validator\Constraint;
+
+use Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+use Symfony\Component\Validator\Constraints\ChoiceValidator;
+
+class EnumValidatorTest extends ConstraintValidatorTestCase
+{
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new Enum(Gender::class));
+        $this->assertNoViolation();
+    }
+
+    public function testBlankStringIsInvalid()
+    {
+        $this->validator->validate('', new Enum(Gender::class));
+        $this->buildViolation('The value you selected is not a valid choice.')
+            ->setParameter('{{ value }}', '""')
+            ->setCode(Enum::NO_SUCH_CHOICE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testValid()
+    {
+        foreach (Gender::instances() as $value) {
+            $this->validator->validate($value, new Enum(Gender::class));
+        }
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidMultiple()
+    {
+        $this->validator->validate([
+            Gender::get(Gender::MALE),
+            Gender::get(Gender::FEMALE),
+        ], new Enum([
+            'class' => Gender::class,
+            'multiple' => true,
+        ]));
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidValues()
+    {
+        foreach (Gender::values() as $value) {
+            $this->validator->validate($value, new Enum([
+                'class' => Gender::class,
+                'asValue' => true,
+            ]));
+        }
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidValue()
+    {
+        $this->validator->validate(42, new Enum(Gender::class));
+        $this->buildViolation('The value you selected is not a valid choice.')
+            ->setParameter('{{ value }}', '42')
+            ->setCode(Enum::NO_SUCH_CHOICE_ERROR)
+            ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new ChoiceValidator();
+    }
+}


### PR DESCRIPTION
For flagged enums, it'll require another constraint and validator simply asking for the enum class and calling `accepts($value)` when validating a raw value (you can't create a flagged enum instance with an invalid value), but it's probably not worth it.

For other usages with flagged enums (as instances or a set of restricted values), this constraint should be enough.