### PR TITLE
Provide a Faker Enum Provider Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Table of Contents
       * [Simple enums](#simple-enums)
       * [Flagged enums](#flagged-enums-1)
     * [Symfony Validator component](#symfony-validator-component)
+    * [Faker enum provider](#faker-enum-provider)
   * [API](#api)
     * [Simple enum](#simple-enum)
     * [Readable enum](#readable-enum)
@@ -644,6 +645,51 @@ AppBundle\Entity\User:
 Where `allowedValues` is a static method of `MyApp\Enum\Gender`, returning allowed instances (:warning: should return values if `asValue` is set to `true`).
 
 Any other [Choice option](http://symfony.com/doc/current/reference/constraints/Choice.html#available-options) (as `multiple`, `min`, ...) is available with the `Enum` constraint.
+
+## Faker enum provider
+
+The PhpEnums library provides an `Elao\Enum\Bridge\Faker\Provider\EnumProvider` to generate fixtures.
+
+### Instantiating the provider
+
+The `EnumProvider` constructor receives as an array parameter a mapping between class aliases and your Enum classes' FQCN:
+
+```php
+
+    <?php
+
+    use Elao\Enum\Bridge\Faker\Provider\EnumProvider;
+
+    $myEnumProvider = new EnumProvider([
+        'Civility' => Namespace\To\MyCivilityEnum::class,
+        'Gender' => Namespace\To\MyGenderEnum::class,
+    ]);
+
+```
+
+### Usage
+
+The `EnumProvider` exposes two public methods:
+
+* `enum(string $enumValueShortcut): EnumInterface` in order to generate deterministic enums
+* `randomEnum(string $enumClassAlias): EnumInterface` in order to generate random enums
+
+Here is an example of a YML [Nelmio/Alice](https://github.com/nelmio/alice) fixtures file:
+
+```yml
+MyEntity:
+    entity1:
+        civility: <enum(Civility::MISTER)>
+        gender: <enum(Gender::MALE>
+        # You can use the pipe character in order to combine flagged enums:
+        permissions: <enum(Permissions::READ|WRITE>
+    entity2:
+        civility: <randomEnum(Civility)>
+        gender: <randomEnum(Gender)>
+        permissions: <randomEnum(Permissions)>
+```
+
+**Note** : _MISTER_ in _<enum(Civility::MISTER)>_ refers to a constant defined in the `Civility` enum class, not to a constant's value ('mister' string for instance).
 
 # API
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "doctrine/doctrine-bundle": "^1.4",
         "doctrine/orm": "^2.4",
         "friendsofphp/php-cs-fixer": "^2.0",
+        "nelmio/alice": "^3.0@RC",
         "phpspec/prophecy": "~1.0",
         "symfony/phpunit-bridge": "^3.2|^4.0",
         "symfony/browser-kit": "^2.8|^3.1|^4.0",

--- a/src/Bridge/Faker/Provider/EnumProvider.php
+++ b/src/Bridge/Faker/Provider/EnumProvider.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Faker\Provider;
+
+use Elao\Enum\EnumInterface;
+use Elao\Enum\Exception\InvalidArgumentException;
+use Elao\Enum\FlaggedEnum;
+
+class EnumProvider
+{
+    /**
+     * Enum mapping as an array with :
+     *
+     * - alias for Enum class as key
+     * - Enum FQCN as value
+     *
+     * Example :
+     *
+     * ```
+     * [
+     *   'Civility' => Civility::class,
+     *   'Gender'   => Gender::class,
+     * ]
+     * ```
+     *
+     * @var array
+     */
+    private $enumMapping = [];
+
+    public function __construct(array $enumMapping)
+    {
+        foreach ($enumMapping as $enumAlias => $enumClass) {
+            $this->ensureEnumClass($enumClass);
+            $this->enumMapping[$enumAlias] = $enumClass;
+        }
+    }
+
+    /**
+     * @param string $enumValueShortcut As <ENUM_CLASS_ALIAS>::<ENUM_VALUE_CONSTANT>
+     *                                  Examples: 'Gender::MALE', 'Gender::FEMALE', 'Permissions::READ|WRITE', etc.
+     *
+     * @throws InvalidArgumentException When the alias part of $enumValueShortcut is not a valid alias
+     *
+     * @return EnumInterface
+     */
+    public function enum(string $enumValueShortcut): EnumInterface
+    {
+        list($enumClassAlias, $constants) = explode('::', $enumValueShortcut);
+
+        if (!array_key_exists($enumClassAlias, $this->enumMapping)) {
+            throw new InvalidArgumentException("$enumClassAlias is not a valid alias");
+        }
+
+        /** @var EnumInterface $class */
+        $class = $this->enumMapping[$enumClassAlias];
+
+        $constants = explode('|', $constants);
+
+        // Flagged Enum if $constants count is greater than one:
+        if (count($constants) > 1) {
+            if (!is_a($class, FlaggedEnum::class, true)) {
+                throw new InvalidArgumentException("$class is not a valid FlaggedEnum");
+            }
+            $value = 0;
+            foreach ($constants as $constant) {
+                $value |= constant($class . '::' . $constant);
+            }
+        } else {
+            $value = constant($class . '::' . current($constants));
+        }
+
+        return $class::get($value);
+    }
+
+    /**
+     * @param string $enumClassAlias
+     *
+     * @throws InvalidArgumentException When $enumClassAlias is not a valid alias
+     *
+     * @return EnumInterface
+     */
+    public function randomEnum(string $enumClassAlias): EnumInterface
+    {
+        if (!array_key_exists($enumClassAlias, $this->enumMapping)) {
+            throw new InvalidArgumentException("$enumClassAlias is not a valid alias");
+        }
+
+        /** @var EnumInterface $class */
+        $class = $this->enumMapping[$enumClassAlias];
+
+        $instances = $class::instances();
+        $randomRank = rand(0, count($instances) - 1);
+
+        return $instances[$randomRank];
+    }
+
+    /**
+     * Make sure that $enumClass is a proper Enum class. Throws exception otherwise.
+     *
+     * @param string $enumClass
+     *
+     * @throws InvalidArgumentException When $enumClass is not a class or is not a proper Enum
+     */
+    private function ensureEnumClass(string $enumClass)
+    {
+        if (!is_a($enumClass, EnumInterface::class, true)) {
+            throw new InvalidArgumentException("$enumClass is not a proper enum class");
+        }
+    }
+}

--- a/src/Bridge/Faker/Provider/EnumProvider.php
+++ b/src/Bridge/Faker/Provider/EnumProvider.php
@@ -97,7 +97,7 @@ class EnumProvider
         $class = $this->enumMapping[$enumClassAlias];
 
         $instances = $class::instances();
-        $randomRank = rand(0, count($instances) - 1);
+        $randomRank = mt_rand(0, count($instances) - 1);
 
         return $instances[$randomRank];
     }

--- a/tests/Fixtures/EnumAware/SimpleEntity.php
+++ b/tests/Fixtures/EnumAware/SimpleEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\EnumAware;
+
+use Elao\Enum\Tests\Fixtures\Enum\Permissions;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+
+class SimpleEntity
+{
+    /** @var Permissions */
+    public $permissions;
+
+    /** @var SimpleEnum */
+    public $simpleEnum;
+}

--- a/tests/Integration/Bridge/Faker/Provider/EnumProviderTest.php
+++ b/tests/Integration/Bridge/Faker/Provider/EnumProviderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Integration\Bridge\Faker\Provider;
+
+use Elao\Enum\Bridge\Faker\Provider\EnumProvider;
+use Elao\Enum\Tests\Fixtures\Enum\Permissions;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+use Elao\Enum\Tests\Fixtures\EnumAware\SimpleEntity;
+use Faker\Factory as FakerGeneratorFactory;
+use Faker\Generator as FakerGenerator;
+use Nelmio\Alice\Loader\NativeLoader;
+
+class EnumProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEnumProvider()
+    {
+        $loader = new EnumLoader();
+
+        $entitySet = $loader->loadData([
+            SimpleEntity::class => [
+                'simple_entity1' => [
+                    'permissions' => '<enum(Permissions::READ|WRITE)>',
+                    'simpleEnum' => '<enum(Simple::FIRST)>',
+                ],
+                'simple_entity2' => [
+                    'permissions' => '<randomEnum(Permissions)>',
+                    'simpleEnum' => '<randomEnum(Simple)>',
+                ],
+            ],
+        ]);
+
+        $entities = $entitySet->getObjects();
+
+        /** @var SimpleEntity $entity1 */
+        $entity1 = $entities['simple_entity1'];
+        $this->assertInstanceOf(Permissions::class, $entity1->permissions);
+        $this->assertInstanceOf(SimpleEnum::class, $entity1->simpleEnum);
+        $this->assertTrue($entity1->permissions->hasFlag(Permissions::READ));
+        $this->assertTrue($entity1->permissions->hasFlag(Permissions::WRITE));
+        $this->assertFalse($entity1->permissions->hasFlag(Permissions::EXECUTE));
+        $this->assertTrue($entity1->simpleEnum->is(SimpleEnum::FIRST));
+
+        /** @var SimpleEntity $entity2 */
+        $entity2 = $entities['simple_entity2'];
+        $this->assertInstanceOf(Permissions::class, $entity2->permissions);
+        $this->assertInstanceOf(SimpleEnum::class, $entity2->simpleEnum);
+    }
+}
+
+class EnumLoader extends NativeLoader
+{
+    protected function createFakerGenerator(): FakerGenerator
+    {
+        $generator = FakerGeneratorFactory::create();
+        $generator->addProvider(new EnumProvider([
+            'Simple' => SimpleEnum::class,
+            'Permissions' => Permissions::class,
+        ]));
+        $generator->seed($this->getSeed());
+
+        return $generator;
+    }
+}

--- a/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
+++ b/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
@@ -50,25 +50,22 @@ class EnumProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorShouldFailWhenEnumClassIsIncorrect(array $mapping)
     {
-        $enumProvider = new EnumProvider($mapping);
+        new EnumProvider($mapping);
     }
 
-    public function provideErroneousEnumMapping(): array
+    public function provideErroneousEnumMapping()
     {
-        return [
+        yield 'EnumProvider constructor with a class that does not exist' => [
             [
-                // Pass to EnumProvider constructor a class that does not exist
-                [
-                    'Simple' => SimpleEnum::class,
-                    'Not-a-class' => '\UnexistingClass',
-                ],
+                'Simple' => SimpleEnum::class,
+                'Not-a-class' => '\UnexistingClass',
             ],
+        ];
+
+        yield 'EnumProvider constructor with a class that is not an Enum' => [
             [
-                // Pass to EnumProvider constructor a class that is not an Enum
-                [
-                    'Simple' => SimpleEnum::class,
-                    'Not-an-enum' => \DateTime::class,
-                ],
+                'Simple' => SimpleEnum::class,
+                'Not-an-enum' => \DateTime::class,
             ],
         ];
     }

--- a/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
+++ b/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Faker\Provider;
+
+use Elao\Enum\Bridge\Faker\Provider\EnumProvider;
+use Elao\Enum\Tests\Fixtures\Enum\Permissions;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+
+class EnumProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEnumMethodShouldReturnExpectedEnums()
+    {
+        $enumProvider = $this->getDefaultProvider();
+
+        $simple = $enumProvider->enum('Simple::FIRST');
+        $this->assertInstanceOf(SimpleEnum::class, $simple);
+        $this->assertTrue($simple->is(SimpleEnum::FIRST));
+
+        /* @var Permissions $permissions */
+        $permissions = $enumProvider->enum('Permissions::READ|WRITE');
+        $this->assertInstanceOf(Permissions::class, $permissions);
+        $this->assertTrue($permissions->hasFlag(Permissions::READ));
+        $this->assertTrue($permissions->hasFlag(Permissions::WRITE));
+        $this->assertFalse($permissions->hasFlag(Permissions::EXECUTE));
+    }
+
+    public function testRandomEnumMethodShouldReturnExpectedEnums()
+    {
+        $enumProvider = $this->getDefaultProvider();
+
+        $simple = $enumProvider->randomEnum('Simple');
+        $this->assertInstanceOf(SimpleEnum::class, $simple);
+
+        $permissions = $enumProvider->randomEnum('Permissions');
+        $this->assertInstanceOf(Permissions::class, $permissions);
+    }
+
+    /**
+     * @expectedException \Elao\Enum\Exception\InvalidArgumentException
+     *
+     * @dataProvider provideErroneousEnumMapping
+     */
+    public function testConstructorShouldFailWhenEnumClassIsIncorrect(array $mapping)
+    {
+        $enumProvider = new EnumProvider($mapping);
+    }
+
+    public function provideErroneousEnumMapping(): array
+    {
+        return [
+            [
+                // Pass to EnumProvider constructor a class that does not exist
+                [
+                    'Simple' => SimpleEnum::class,
+                    'Not-a-class' => '\UnexistingClass',
+                ],
+            ],
+            [
+                // Pass to EnumProvider constructor a class that is not an Enum
+                [
+                    'Simple' => SimpleEnum::class,
+                    'Not-an-enum' => \DateTime::class,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @expectedException \Elao\Enum\Exception\InvalidArgumentException
+     */
+    public function testEnumMethodShouldThrowErrorIfFlaggedEnumIsIncorrect()
+    {
+        $enumProvider = $this->getDefaultProvider();
+
+        // Simple is not a flagged enum. An InvalidArgumentException should therefore be thrown.
+        $enumProvider->enum('Simple::FIRST|SECOND');
+    }
+
+    private function getDefaultProvider(): EnumProvider
+    {
+        return new EnumProvider([
+            'Simple' => SimpleEnum::class,
+            'Permissions' => Permissions::class,
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Elao/PhpEnums/issues/29

- [x] Method `enum(EnumAlias::VALUE)` using pipes for flagged enums, e.g: enum(Permissions::WRITE|READ)
- [x] Method `randomEnum(EnumAlias)`
- [x] Unit tests for EnumProvider
- [x] Integration tests (loading Alice fixtures)
- [x] Update README, `Integrations` part