### PR TITLE
Add an AutoDiscoveredValuesTrait to automatically guess values from constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,13 @@ final class Gender extends Enum
 
 > 📝 It's recommended to make your enums classes `final`, because it won't make sense to extend them in most situations (unless you're creating a new base enum type), and you won't need to mock an enum type.
 
+> 💡 You can also use the `AutoDiscoveredValuesTrait` to automagically guess values from the constants defined in your enum, so you don't have to implement `EnumInterface::values()` yourself.
+
 Get an instance of your enum type:
 
 ```php
 <?php
-$enum = Gender::get(Gender::Male); 
+$enum = Gender::get(Gender::Male);
 ```
 
 You can easily retrieve the enumeration's value by using `$enum->getValue();`

--- a/src/AutoDiscoveredValuesTrait.php
+++ b/src/AutoDiscoveredValuesTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum;
+
+trait AutoDiscoveredValuesTrait
+{
+    /** @var array */
+    private static $guessedValues = [];
+
+    /**
+     * @see EnumInterface::values()
+     *
+     * @return int[]|string[]
+     */
+    public static function values(): array
+    {
+        $enumType = static::class;
+
+        if (!isset(self::$guessedValues[$enumType])) {
+            $values = (new \ReflectionClass($enumType))->getConstants();
+
+            if (is_a($enumType, FlaggedEnum::class, true)) {
+                $values = array_filter($values, function ($v) {
+                    return 0 === ($v & $v - 1) && $v > 0;
+                });
+            }
+
+            self::$guessedValues[$enumType] = array_values($values);
+        }
+
+        return self::$guessedValues[$enumType];
+    }
+}

--- a/tests/Unit/AutoDiscoveredValuesTraitTest.php
+++ b/tests/Unit/AutoDiscoveredValuesTraitTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) 2016 Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit;
+
+use Elao\Enum\AutoDiscoveredValuesTrait;
+use Elao\Enum\Enum;
+use Elao\Enum\FlaggedEnum;
+
+class AutoDiscoveredValuesTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItAutoDiscoveredValuesBasedOnAvailableConstants()
+    {
+        $this->assertSame(['foo', 'bar', 'baz'], AutoDiscoveredEnum::values());
+    }
+
+    public function testItAutoDiscoveredValuesBasedOnAvailableBitFlagConstants()
+    {
+        $this->assertSame([1, 2, 4], AutoDiscoveredFlaggedEnum::values());
+    }
+}
+
+final class AutoDiscoveredEnum extends Enum
+{
+    use AutoDiscoveredValuesTrait;
+
+    const FOO = 'foo';
+    const BAR = 'bar';
+    const BAZ = 'baz';
+}
+
+final class AutoDiscoveredFlaggedEnum extends FlaggedEnum
+{
+    use AutoDiscoveredValuesTrait;
+
+    const FOO = 1;
+    const BAR = 2;
+    const BAZ = 4;
+
+    const NOT_A_BIT_FLAG = 3;
+}


### PR DESCRIPTION
Relates to #5.

A trait is a good tradeoff to me.

About naming:

1. `AutoDiscoveredValuesTrait`
1. `AutoDiscoverableValuesTrait`

?