### PR TITLE
Make Enum class implements \Serializable interface

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -12,8 +12,9 @@ namespace Elao\Enum;
 
 use Elao\Enum\Exception\InvalidValueException;
 use Elao\Enum\Exception\LogicException;
+use Elao\Enum\Exception\NotSerializableException;
 
-abstract class Enum implements EnumInterface
+abstract class Enum implements EnumInterface, \Serializable
 {
     /**
      * Cached array of enum instances by enum type (FQCN).
@@ -143,5 +144,35 @@ abstract class Enum implements EnumInterface
     public function is($value): bool
     {
         return $this->getValue() === $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws NotSerializableException When Enum value type is neither "string" not "int"
+     */
+    public function serialize(): string
+    {
+        if(!is_string($this->getValue()) && !is_int($this->getValue())) {
+            throw new NotSerializableException('Only values of type "string" or "int" can be serialized');
+        }
+
+        return (string)$this->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        if(static::accepts($serialized)) {
+            $this->value = $serialized;
+            return;
+        }
+        if(is_numeric($serialized) && static::accepts(intval($serialized))) {
+            $this->value = intval($serialized);
+            return;
+        }
+
+        throw new InvalidValueException($serialized, static::class);
     }
 }

--- a/src/Exception/NotSerializableException.php
+++ b/src/Exception/NotSerializableException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Elao\Enum\Exception;
+
+class NotSerializableException extends \InvalidArgumentException implements ExceptionInterface
+{
+
+}

--- a/tests/Fixtures/Enum/MathConstant.php
+++ b/tests/Fixtures/Enum/MathConstant.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\Enum;
+
+use Elao\Enum\Enum;
+
+/**
+ * @method static MathConstant PI()
+ * @method static MathConstant MALE()
+ * @method static MathConstant FEMALE()
+ */
+final class MathConstant extends Enum
+{
+    const PI = 3.14159;
+    const EULER = 2.71828;
+    const GOLDEN = 1.61803;
+
+    public static function values(): array
+    {
+        return [
+            self::PI,
+            self::EULER,
+            self::GOLDEN,
+        ];
+    }
+}

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -11,6 +11,8 @@
 namespace Elao\Enum\Tests\Unit;
 
 use Elao\Enum\Tests\Fixtures\Enum\ExtendedSimpleEnum;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+use Elao\Enum\Tests\Fixtures\Enum\MathConstant;
 use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
 
 class EnumTest extends \PHPUnit_Framework_TestCase
@@ -101,5 +103,60 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $enum = SimpleEnum::get(SimpleEnum::SECOND);
 
         $this->assertTrue($enum->is(2));
+    }
+
+    public function testSerialize()
+    {
+        $enum = SimpleEnum::get(SimpleEnum::SECOND);
+        $expected = sprintf(
+            'C:%d:"%s":%d:{%s}',
+            strlen(SimpleEnum::class),
+            SimpleEnum::class,
+            count($enum),
+            (string)SimpleEnum::SECOND
+        );
+
+        $this->assertEquals($expected, \serialize($enum));
+    }
+
+    /**
+     * @expectedException \Elao\Enum\Exception\NotSerializableException
+     * @expectedExceptionMessage Only values of type "string" or "int" can be serialized
+     */
+    public function testExceptionIsRaisedWhenSerializingValuesThatAreNotAllowed()
+    {
+        $enum = MathConstant::get(MathConstant::PI);
+        \serialize($enum);
+    }
+
+    public function testUnserialize()
+    {
+        $serializedEnumWithStringValues = sprintf(
+            'C:%d:"%s":%d:{%s}',
+            strlen(Gender::class),
+            Gender::class,
+            strlen(Gender::FEMALE),
+            Gender::FEMALE
+        );
+        $serializedEnumWithIntegerValues = sprintf(
+            'C:%d:"%s":%d:{%s}',
+            strlen(SimpleEnum::class),
+            SimpleEnum::class,
+            strlen((string)SimpleEnum::SECOND),
+            (string)SimpleEnum::SECOND
+        );
+
+        $this->assertTrue(Gender::get(Gender::FEMALE)->equals(\unserialize($serializedEnumWithStringValues)));
+        $this->assertTrue(SimpleEnum::get(SimpleEnum::SECOND)->equals(\unserialize($serializedEnumWithIntegerValues)));
+    }
+
+    /**
+     * @expectedException \Elao\Enum\Exception\InvalidValueException
+     * @expectedExceptionMessage "invalid_value" is not an acceptable value for "Elao\Enum\Tests\Fixtures\Enum\SimpleEnum" enum.
+     */
+    public function testExceptionIsRaisedWhenUnserializingNotExistingValue()
+    {
+        $serialized = sprintf('C:%d:"%s":13:{invalid_value}', strlen(SimpleEnum::class), SimpleEnum::class);
+        \unserialize($serialized);
     }
 }


### PR DESCRIPTION
Implementation of feature asked in issue #26

Only values of type `string` and `int` are serializable with this PR since they are the recommended type in the documentation (https://github.com/skwi/PhpEnums#usage)

This is quite a constraint so let me know if it should be avoided.