### PR TITLE
Change AutoDiscoveredValuesTrait to use constant values as keys

### DIFF
--- a/src/AutoDiscoveredValuesTrait.php
+++ b/src/AutoDiscoveredValuesTrait.php
@@ -40,7 +40,7 @@ trait AutoDiscoveredValuesTrait
                 });
             }
 
-            self::$guessedValues[$enumType] = array_values($values);
+            self::$guessedValues[$enumType] = array_combine($values, $values);
         }
 
         return self::$guessedValues[$enumType];

--- a/tests/Unit/AutoDiscoveredValuesTraitTest.php
+++ b/tests/Unit/AutoDiscoveredValuesTraitTest.php
@@ -20,7 +20,7 @@ class AutoDiscoveredValuesTraitTest extends TestCase
 {
     public function testItAutoDiscoveredValuesBasedOnAvailableConstants()
     {
-        $this->assertSame(['foo', 'bar', 'baz'], AutoDiscoveredEnum::values());
+        $this->assertSame(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], AutoDiscoveredEnum::values());
     }
 
     /**
@@ -28,12 +28,12 @@ class AutoDiscoveredValuesTraitTest extends TestCase
      */
     public function testPHP71ItAutoDiscoveredValuesBasedOnAvailableConstants()
     {
-        $this->assertSame(['foo', 'bar', 'baz'], Php71AutoDiscoveredEnum::values());
+        $this->assertSame(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], Php71AutoDiscoveredEnum::values());
     }
 
     public function testItAutoDiscoveredValuesBasedOnAvailableBitFlagConstants()
     {
-        $this->assertSame([1, 2, 4], AutoDiscoveredFlaggedEnum::values());
+        $this->assertSame([1 => 1, 2 => 2, 4 => 4], AutoDiscoveredFlaggedEnum::values());
     }
 }
 


### PR DESCRIPTION
Hi, can I have this change? It aids with https://github.com/Elao/PhpEnums/issues/46

For some enums, it's ok to have label same as value. In those cases, this allows to not having to define neither values() and neither readables(). Shouldn't pose too big risk of BC break.