### PR TITLE
Add ScalarToEnumTransformer

### DIFF
--- a/src/Bridge/Symfony/Form/DataTransformer/ScalarToEnumTransformer.php
+++ b/src/Bridge/Symfony/Form/DataTransformer/ScalarToEnumTransformer.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Symfony\Form\DataTransformer;
+
+use Elao\Enum\EnumInterface;
+use Elao\Enum\Exception\InvalidValueException;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class ScalarToEnumTransformer implements DataTransformerInterface
+{
+    /** @var string|EnumInterface */
+    private $enumClass;
+
+    public function __construct(string $enumClass)
+    {
+        if (!is_a($enumClass, EnumInterface::class, true)) {
+            throw new InvalidArgumentException(sprintf(
+                '"%s" is not an instance of "%s"',
+                $enumClass,
+                EnumInterface::class
+            ));
+        }
+
+        $this->enumClass = $enumClass;
+    }
+
+    /**
+     * Transforms EnumInterface object to a scalar value.
+     *
+     * @param EnumInterface $value EnumInterface instance
+     *
+     * @throws TransformationFailedException When the transformation fails
+     *
+     * @return int|string Value of EnumInterface
+     */
+    public function transform($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!$value instanceof $this->enumClass) {
+            throw new TransformationFailedException(sprintf(
+                'Expected instance of "%s". Got "%s".',
+                $this->enumClass,
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+
+        return $value->getValue();
+    }
+
+    /**
+     * Transforms scalar enum value to enumeration instance.
+     *
+     * @param int|string $value Value accepted by EnumInterface
+     *
+     * @throws TransformationFailedException When the transformation fails
+     *
+     * @return EnumInterface|null A single FlaggedEnum instance or null
+     */
+    public function reverseTransform($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return $this->enumClass::get($value);
+        } catch (InvalidValueException $exception) {
+            throw new TransformationFailedException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+}

--- a/tests/Fixtures/Integration/Symfony/app/config/routing.yml
+++ b/tests/Fixtures/Integration/Symfony/app/config/routing.yml
@@ -5,3 +5,7 @@ readable_enum_form:
 flagged_enum_form:
     path: '/form-type/flagged-enum'
     defaults: { _controller: 'TestBundle:FormType:flaggedEnumForm' }
+
+form_with_scalar_transformer:
+    path: '/form-type/scalar-transformer-enum'
+    defaults: { _controller: 'TestBundle:FormType:enumFormUtilizingScalarTransformer' }

--- a/tests/Integration/Bridge/Symfony/Form/EnumTypeTest.php
+++ b/tests/Integration/Bridge/Symfony/Form/EnumTypeTest.php
@@ -86,4 +86,34 @@ class EnumTypeTest extends WebTestCase
 
         $this->assertSame(['form[permissions]' => []], $form->getValues());
     }
+
+    public function testEnumFormUtilizingScalarTransformer()
+    {
+        $client = static::createClient();
+        $crawler = $client->request(Request::METHOD_GET, '/form-type/scalar-transformer-enum');
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([
+            ['selected', 'male', 'customMaleLabel'],
+            ['', 'female', 'customFemaleLabel'],
+        ], $crawler->filter('form select[name="form[gender]"] option')->extract(['selected', 'value', '_text']));
+        $this->assertSame([
+            ['', '1', 'customOneLabel'],
+            ['selected', '2', 'customSecondLabel'],
+        ], $crawler->filter('form select[name="form[simpleEnum]"] option')->extract(['selected', 'value', '_text']));
+
+        $form = $crawler->filter('form')->form();
+        $form['form[gender]'] = 'female';
+        $form['form[simpleEnum]'] = '1';
+
+        $crawler = $client->submit($form);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $form = $crawler->filter('form')->form();
+
+        $this->assertSame(['form[gender]' => 'female', 'form[simpleEnum]' => '1'], $form->getValues());
+    }
 }

--- a/tests/Unit/Bridge/Symfony/Form/DataTransformer/ScalarToEnumTransformerTest.php
+++ b/tests/Unit/Bridge/Symfony/Form/DataTransformer/ScalarToEnumTransformerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Form\DataTransformer;
+
+use Elao\Enum\Bridge\Symfony\Form\DataTransformer\ScalarToEnumTransformer;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+use PHPUnit\Framework\TestCase;
+
+class ScalarToEnumTransformerTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedExceptionMessage "stdClass" is not an instance of "Elao\Enum\EnumInterface"
+     */
+    public function testThrowsExceptionIfNotEnumInstance()
+    {
+        new ScalarToEnumTransformer(\stdClass::class);
+    }
+
+    public function testTransform()
+    {
+        $transformer = new ScalarToEnumTransformer(SimpleEnum::class);
+
+        $this->assertSame(SimpleEnum::FIRST, $transformer->transform(SimpleEnum::FIRST()));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     * @expectedExceptionMessage Expected instance of "Elao\Enum\Tests\Fixtures\Enum\SimpleEnum". Got "string".
+     */
+    public function testTransformThrowsExceptionOnNonEnum()
+    {
+        $transformer = new ScalarToEnumTransformer(SimpleEnum::class);
+
+        $transformer->transform('foo');
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new ScalarToEnumTransformer(SimpleEnum::class);
+
+        $this->assertSame(SimpleEnum::FIRST(), $transformer->reverseTransform(SimpleEnum::FIRST));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     * @expectedExceptionMessage "1" is not an acceptable value for "Elao\Enum\Tests\Fixtures\Enum\SimpleEnum
+     */
+    public function testReverseTransformThrowsExceptionOnValueNotInEnum()
+    {
+        $transformer = new ScalarToEnumTransformer(SimpleEnum::class);
+
+        $transformer->reverseTransform('1');
+    }
+}


### PR DESCRIPTION
I found EnumType very limiting, because it enforces either Enum instances inside choices, or scalar value as output.

This is inconvenient, because it's common to have scalar key-value pairs stored as an array in class constant. Storing there objects is not possible.

So, this transformer is meant to be used in conjunction with normal ChoiceType and scalar choices.