### PR TITLE
Allow usage of FCQN instead of aliases in Faker provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ $provider = new EnumProvider([
 The provider exposes two public methods:
 
 * `EnumProvider::enum(string $enumValueShortcut): EnumInterface` in order to generate deterministic enums
-* `EnumProvider::randomEnum(string $enumClassAlias): EnumInterface` in order to generate random enums
+* `EnumProvider::randomEnum(string $enumClassOrAlias): EnumInterface` in order to generate random enums
 
 ### Usage with Alice
 
@@ -723,12 +723,13 @@ The following example shows how to use the provider within a Yaml fixture file:
 MyEntity:
     entity1:
         civility: <enum(Civility::MISTER)>
-        gender: <enum(Gender::MALE>
+        # You can use enums outside of map if you specify full path to Enum class:
+        gender: <enum("App\Model\Enum\Gender::MALE">
         # You can use the pipe character in order to combine flagged enums:
         permissions: <enum(Permissions::READ|WRITE>
     entity2:
         civility: <randomEnum(Civility)>
-        gender: <randomEnum(Gender)>
+        gender: <randomEnum("App\Model\Enum\Gender")>
         permissions: <randomEnum(Permissions)>
 ```
 

--- a/src/Bridge/Faker/Provider/EnumProvider.php
+++ b/src/Bridge/Faker/Provider/EnumProvider.php
@@ -35,7 +35,7 @@ class EnumProvider
      */
     private $enumMapping = [];
 
-    public function __construct(array $enumMapping)
+    public function __construct(array $enumMapping = [])
     {
         foreach ($enumMapping as $enumAlias => $enumClass) {
             $this->ensureEnumClass($enumClass);
@@ -44,8 +44,8 @@ class EnumProvider
     }
 
     /**
-     * @param string $enumValueShortcut As <ENUM_CLASS_ALIAS>::<ENUM_VALUE_CONSTANT>
-     *                                  Examples: 'Gender::MALE', 'Gender::FEMALE', 'Permissions::READ|WRITE', etc.
+     * @param string $enumValueShortcut As <ENUM_CLASS_ALIAS_OR_ENUM_FCQN>::<ENUM_VALUE_CONSTANT>
+     *                                  Examples: 'Gender::MALE', 'App\Enum\Gender::FEMALE', 'Permissions::READ|WRITE', etc.
      *
      * @throws InvalidArgumentException When the alias part of $enumValueShortcut is not a valid alias
      *
@@ -53,14 +53,11 @@ class EnumProvider
      */
     public function enum(string $enumValueShortcut): EnumInterface
     {
-        list($enumClassAlias, $constants) = explode('::', $enumValueShortcut);
-
-        if (!array_key_exists($enumClassAlias, $this->enumMapping)) {
-            throw new InvalidArgumentException("$enumClassAlias is not a valid alias");
-        }
+        list($enumClassOrAlias, $constants) = explode('::', $enumValueShortcut);
 
         /** @var EnumInterface $class */
-        $class = $this->enumMapping[$enumClassAlias];
+        $class = $this->enumMapping[$enumClassOrAlias] ?? $enumClassOrAlias;
+        $this->ensureEnumClass($class);
 
         $constants = explode('|', $constants);
 
@@ -81,20 +78,17 @@ class EnumProvider
     }
 
     /**
-     * @param string $enumClassAlias
+     * @param string $enumClassOrAlias
      *
      * @throws InvalidArgumentException When $enumClassAlias is not a valid alias
      *
      * @return EnumInterface
      */
-    public function randomEnum(string $enumClassAlias): EnumInterface
+    public function randomEnum(string $enumClassOrAlias): EnumInterface
     {
-        if (!array_key_exists($enumClassAlias, $this->enumMapping)) {
-            throw new InvalidArgumentException("$enumClassAlias is not a valid alias");
-        }
-
         /** @var EnumInterface $class */
-        $class = $this->enumMapping[$enumClassAlias];
+        $class = $this->enumMapping[$enumClassOrAlias] ?? $enumClassOrAlias;
+        $this->ensureEnumClass($class);
 
         $instances = $class::instances();
         $randomRank = mt_rand(0, count($instances) - 1);

--- a/tests/Fixtures/EnumAware/SimpleEntity.php
+++ b/tests/Fixtures/EnumAware/SimpleEntity.php
@@ -10,6 +10,7 @@
 
 namespace Elao\Enum\Tests\Fixtures\EnumAware;
 
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
 use Elao\Enum\Tests\Fixtures\Enum\Permissions;
 use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
 
@@ -20,4 +21,7 @@ class SimpleEntity
 
     /** @var SimpleEnum */
     public $simpleEnum;
+
+    /** @var Gender */
+    public $gender;
 }

--- a/tests/Integration/Bridge/Faker/Provider/EnumProviderTest.php
+++ b/tests/Integration/Bridge/Faker/Provider/EnumProviderTest.php
@@ -11,6 +11,7 @@
 namespace Elao\Enum\Tests\Integration\Bridge\Faker\Provider;
 
 use Elao\Enum\Bridge\Faker\Provider\EnumProvider;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
 use Elao\Enum\Tests\Fixtures\Enum\Permissions;
 use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
 use Elao\Enum\Tests\Fixtures\EnumAware\SimpleEntity;
@@ -30,10 +31,12 @@ class EnumProviderTest extends TestCase
                 'simple_entity1' => [
                     'permissions' => '<enum(Permissions::READ|WRITE)>',
                     'simpleEnum' => '<enum(Simple::FIRST)>',
+                    'gender' => '<enum("Elao\Enum\Tests\Fixtures\Enum\Gender::MALE")>',
                 ],
                 'simple_entity2' => [
                     'permissions' => '<randomEnum(Permissions)>',
                     'simpleEnum' => '<randomEnum(Simple)>',
+                    'gender' => '<randomEnum("Elao\Enum\Tests\Fixtures\Enum\Gender")>',
                 ],
             ],
         ]);
@@ -44,15 +47,18 @@ class EnumProviderTest extends TestCase
         $entity1 = $entities['simple_entity1'];
         $this->assertInstanceOf(Permissions::class, $entity1->permissions);
         $this->assertInstanceOf(SimpleEnum::class, $entity1->simpleEnum);
+        $this->assertInstanceOf(Gender::class, $entity1->gender);
         $this->assertTrue($entity1->permissions->hasFlag(Permissions::READ));
         $this->assertTrue($entity1->permissions->hasFlag(Permissions::WRITE));
         $this->assertFalse($entity1->permissions->hasFlag(Permissions::EXECUTE));
         $this->assertTrue($entity1->simpleEnum->is(SimpleEnum::FIRST));
+        $this->assertTrue($entity1->gender->is(Gender::MALE));
 
         /** @var SimpleEntity $entity2 */
         $entity2 = $entities['simple_entity2'];
         $this->assertInstanceOf(Permissions::class, $entity2->permissions);
         $this->assertInstanceOf(SimpleEnum::class, $entity2->simpleEnum);
+        $this->assertInstanceOf(Gender::class, $entity2->gender);
     }
 }
 

--- a/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
+++ b/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
@@ -11,6 +11,7 @@
 namespace Elao\Enum\Tests\Unit\Bridge\Faker\Provider;
 
 use Elao\Enum\Bridge\Faker\Provider\EnumProvider;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
 use Elao\Enum\Tests\Fixtures\Enum\Permissions;
 use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,10 @@ class EnumProviderTest extends TestCase
         $simple = $enumProvider->enum('Simple::FIRST');
         $this->assertInstanceOf(SimpleEnum::class, $simple);
         $this->assertTrue($simple->is(SimpleEnum::FIRST));
+
+        $gender = $enumProvider->enum('Elao\Enum\Tests\Fixtures\Enum\Gender::MALE');
+        $this->assertInstanceOf(Gender::class, $gender);
+        $this->assertTrue($gender->is(Gender::MALE));
 
         /* @var Permissions $permissions */
         $permissions = $enumProvider->enum('Permissions::READ|WRITE');
@@ -39,6 +44,9 @@ class EnumProviderTest extends TestCase
 
         $simple = $enumProvider->randomEnum('Simple');
         $this->assertInstanceOf(SimpleEnum::class, $simple);
+
+        $gender = $enumProvider->enum('Elao\Enum\Tests\Fixtures\Enum\Gender::MALE');
+        $this->assertInstanceOf(Gender::class, $gender);
 
         $permissions = $enumProvider->randomEnum('Permissions');
         $this->assertInstanceOf(Permissions::class, $permissions);


### PR DESCRIPTION
This allows avoiding defining alias map if I want to use this provider