### PR TITLE
Fix Enum constraint deserialization

### DIFF
--- a/src/Bridge/Symfony/Validator/Constraint/Enum.php
+++ b/src/Bridge/Symfony/Validator/Constraint/Enum.php
@@ -95,4 +95,22 @@ class Enum extends Choice
     {
         return ['class'];
     }
+
+    /**
+     * Fixup deserialized enum instances by replacing them with actual multiton instances,
+     * so strict comparison works.
+     *
+     * {@inheritdoc}
+     */
+    public function __wakeup()
+    {
+        if (!$this->asValue && \is_array($this->choices)) {
+            $this->choices = array_map(function (EnumInterface $enum): EnumInterface {
+                /** @var string|EnumInterface $enumClass */
+                $enumClass = \get_class($enum);
+
+                return $enumClass::get($enum->getValue());
+            }, $this->choices);
+        }
+    }
 }

--- a/tests/Unit/Bridge/Symfony/Validator/Constraint/EnumTest.php
+++ b/tests/Unit/Bridge/Symfony/Validator/Constraint/EnumTest.php
@@ -72,4 +72,19 @@ class EnumTest extends TestCase
     {
         new Enum(['class' => SimpleEnum::class, 'choices' => ['bar']]);
     }
+
+    public function testDeserializingConstraintRespectsMultitonInstance()
+    {
+        $constraint = new Enum(['class' => SimpleEnum::class, 'choices' => [
+            SimpleEnum::FIRST,
+            SimpleEnum::SECOND,
+        ]]);
+
+        $constraint = unserialize(serialize($constraint));
+
+        $this->assertSame([
+            SimpleEnum::get(SimpleEnum::FIRST),
+            SimpleEnum::get(SimpleEnum::SECOND),
+        ], $constraint->choices);
+    }
 }


### PR DESCRIPTION
When the constraint is serialized (to be cached) and the `choice` option is provided (and expecting enum instances and not just values), deserialization of the choice option will not use `EnumInterface::get()` and thus won't create the proper multiton instances, making strict comparisons fail.
This fixes it by replacing deserialized instances by proper ones.