### PR TITLE
Use `defined` call to check if constant exists

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -83,8 +83,7 @@ abstract class Enum implements EnumInterface
      */
     public static function __callStatic($name, $arguments = []): EnumInterface
     {
-        $value = @\constant('static::' . $name);
-        if (null === $value) {
+        if (!\defined('static::' . $name)) {
             throw new \BadMethodCallException(sprintf(
                 'No constant named "%s" exists in class "%s"',
                 $name,
@@ -92,7 +91,7 @@ abstract class Enum implements EnumInterface
             ));
         }
 
-        return static::get($value);
+        return static::get(\constant('static::' . $name));
     }
 
     /**


### PR DESCRIPTION
Use `defined` to check if a constant is defined on a class instead of trying to get the constant value and suppressing errors (which has a slightly negative impact on performance)