### PR TITLE
Allow to generate doctrine DBAL types from config

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,6 +11,7 @@ EOF;
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude('tests/Fixtures/Integration/Symfony/var')
+    ->exclude('tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest')
 ;
 
 return PhpCsFixer\Config::create()

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Table of Contents
     * [Shortcuts](#shortcuts)
   * [Integrations](#integrations)
     * [Doctrine](#doctrine)
+      * [In a Symfony app](#in-a-symfony-app)
       * [Create the DBAL type](#create-the-dbal-type)
       * [Register the DBAL type](#register-the-dbal-type)
         * [Manually](#manually)
@@ -456,6 +457,20 @@ You can store the raw value of an enumeration in the database, but still manipul
 
 However, this library can help you by providing abstract classes for both string and integer based enumerations.
 
+### In a Symfony app
+
+This configuration is equivalent to the following sections explaining how to create a custom Doctrine DBAL type for your enums. 
+
+```yaml
+elao_enum:
+    doctrine:
+        types:
+            App\Enum\GenderEnum: gender
+            App\Enum\Permissions: { name: permissions, type: int } # values are stored as integers
+```
+
+It'll actually generate & register the types classes for you, saving you from writing this boilerplate code.
+
 ### Create the DBAL type
 
 First, create your DBAL type by extending either `AbstractEnumType` (string based enum) or `AbstractIntegerEnumType` (integer based enum, for flagged enums for instance):
@@ -519,7 +534,6 @@ $conn->getDatabasePlatform()->registerDoctrineTypeMapping(GenderEnumType::NAME, 
 refs: 
 
 - [Registering custom Mapping Types](https://symfony.com/doc/current/doctrine/dbal.html#registering-custom-mapping-types)
-- [Registering custom Mapping Types in the SchemaTool](https://symfony.com/doc/current/doctrine/dbal.html#registering-custom-mapping-types-in-the-schematool)
 
 ```yml
 # config/packages/doctrine.yaml
@@ -527,8 +541,6 @@ doctrine:
     dbal:
         types:
             gender: App\Doctrine\DBAL\Types\GenderEnumType
-        mapping_types:
-            gender: string
 ```
 
 ### Mapping

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="tests/Fixtures/Integration/Symfony/bootstrap.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <server name="KERNEL_CLASS" value="AppKernel" />

--- a/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
+++ b/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\DBAL\Types;
+
+/**
+ * @internal
+ */
+class TypesDumper
+{
+    const MARKER = 'ELAO_ENUM_DT';
+
+    public function dumpToFile(string $file, array $types)
+    {
+        file_put_contents($file, $this->dump($types));
+    }
+
+    private function dump(array $types): string
+    {
+        $code = "<?php\n";
+        foreach ($types as [$class, $type, $name]) {
+            $code .= $this->getTypeCode($class, $type, $name);
+        }
+
+        return $code;
+    }
+
+    private function getTypeCode(string $class, string $type, string $name): string
+    {
+        $baseClass = $type === 'int' ? AbstractIntegerEnumType::class : AbstractEnumType::class;
+        $fqcn = self::getTypeClassname($class);
+        $classname = basename(str_replace('\\', '/', $fqcn));
+        $ns = substr($fqcn, 0, -\strlen($classname) - 1);
+
+        return <<<PHP
+
+namespace $ns;
+
+if (!\class_exists('\\$fqcn')) {
+    class $classname extends \\{$baseClass}
+    {
+        const NAME = '$name';
+
+        protected function getEnumClass(): string
+        {
+            return \\{$class}::class;
+        }
+
+        public function getName(): string
+        {
+            return static::NAME;
+        }
+    }
+}
+
+PHP;
+    }
+
+    public static function getTypeClassname(string $class): string
+    {
+        return self::MARKER . "\\{$class}Type";
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineDBALTypesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineDBALTypesPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Elao\Enum\Bridge\Doctrine\DBAL\Types\TypesDumper;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DoctrineDBALTypesPass implements CompilerPassInterface
+{
+    /** @var string */
+    private $typesFilePath;
+
+    public function __construct(string $typesFilePath)
+    {
+        $this->typesFilePath = $typesFilePath;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('.elao_enum.doctrine_types')) {
+            return;
+        }
+
+        $types = $container->getParameter('.elao_enum.doctrine_types');
+
+        (new TypesDumper())->dumpToFile($this->typesFilePath, $types);
+
+        $container->getDefinition('doctrine.dbal.connection_factory')->setFile($this->typesFilePath);
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension.php
@@ -10,15 +10,43 @@
 
 namespace Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection;
 
+use Elao\Enum\Bridge\Doctrine\DBAL\Types\TypesDumper;
 use Elao\Enum\Bridge\Symfony\HttpKernel\Controller\ArgumentResolver\EnumValueResolver;
 use Elao\Enum\Bridge\Symfony\Serializer\Normalizer\EnumNormalizer;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class ElaoEnumExtension extends Extension
+class ElaoEnumExtension extends Extension implements PrependExtensionInterface
 {
+    public function prepend(ContainerBuilder $container)
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+        if (!isset($bundles['DoctrineBundle'])) {
+            return;
+        }
+
+        $configs = $container->getExtensionConfig($this->getAlias());
+        $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
+
+        if (!($types = $config['doctrine']['types'] ?? false)) {
+            return;
+        }
+
+        $doctrineTypesConfig = [];
+        foreach ($types as $class => $value) {
+            $doctrineTypesConfig[$value['name']] = TypesDumper::getTypeClassname($class);
+        }
+
+        $container->prependExtensionConfig('doctrine', [
+            'dbal' => [
+                'types' => $doctrineTypesConfig,
+            ],
+        ]);
+    }
+
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
@@ -32,6 +60,12 @@ class ElaoEnumExtension extends Extension
 
         if (!$this->isConfigEnabled($container, $config['serializer'])) {
             $container->removeDefinition(EnumNormalizer::class);
+        }
+
+        if ($types = $config['doctrine']['types'] ?? false) {
+            $container->setParameter('.elao_enum.doctrine_types', array_map(static function (string $k, array $v): array {
+                return [$k, $v['type'], $v['name']];
+            }, array_keys($types), $types));
         }
     }
 

--- a/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
+++ b/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
@@ -10,8 +10,18 @@
 
 namespace Elao\Enum\Bridge\Symfony\Bundle;
 
+use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineDBALTypesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ElaoEnumBundle extends Bundle
 {
+    const DOCTRINE_TYPES_FILENAME = 'elao_enum_doctrine_types.php';
+
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DoctrineDBALTypesPass($container->getParameter('kernel.cache_dir') . '/' . self::DOCTRINE_TYPES_FILENAME));
+    }
 }

--- a/src/Bridge/Symfony/Bundle/Resources/config/schema/elao_enum.xsd
+++ b/src/Bridge/Symfony/Bundle/Resources/config/schema/elao_enum.xsd
@@ -11,6 +11,7 @@
         <xsd:choice maxOccurs="unbounded">
             <xsd:element name="serializer" type="serializer" minOccurs="0" maxOccurs="1" />
             <xsd:element name="argument_value_resolver" type="argument_value_resolver" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="doctrine" type="doctrine" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
     </xsd:complexType>
 
@@ -21,5 +22,24 @@
     <xsd:complexType name="argument_value_resolver">
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
+
+    <xsd:complexType name="doctrine">
+        <xsd:sequence>
+            <xsd:element name="type" type="doctrine_type" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="doctrine_type">
+        <xsd:attribute name="class" type="xsd:string" use="required" />
+        <xsd:attribute name="type" type="doctrine_type_type" default="string" />
+        <xsd:attribute name="name" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:simpleType name="doctrine_type_type">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="string" />
+            <xsd:enumeration value="int" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
 </xsd:schema>

--- a/tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest/dumped_types.php
+++ b/tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest/dumped_types.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ELAO_ENUM_DT\Foo\Bar;
+
+if (!\class_exists('\ELAO_ENUM_DT\Foo\Bar\BazType')) {
+    class BazType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
+    {
+        const NAME = 'baz';
+
+        protected function getEnumClass(): string
+        {
+            return \Foo\Bar\Baz::class;
+        }
+
+        public function getName(): string
+        {
+            return static::NAME;
+        }
+    }
+}
+
+namespace ELAO_ENUM_DT\Foo\Bar;
+
+if (!\class_exists('\ELAO_ENUM_DT\Foo\Bar\QuxType')) {
+    class QuxType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractIntegerEnumType
+    {
+        const NAME = 'qux';
+
+        protected function getEnumClass(): string
+        {
+            return \Foo\Bar\Qux::class;
+        }
+
+        public function getName(): string
+        {
+            return static::NAME;
+        }
+    }
+}

--- a/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/xml/doctrine_types.xml
+++ b/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/xml/doctrine_types.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:elao-enum="http://elao.com/schema/dic/elao_enum"
+           xsi:schemaLocation="http://elao.com/schema/dic/elao_enum http://elao.com/schema/dic/elao_enum/elao_enum.xsd">
+
+    <elao-enum:config>
+        <elao-enum:doctrine>
+            <elao-enum:type class="Elao\Enum\Tests\Fixtures\Enum\Gender" name="gender" />
+            <elao-enum:type class="Elao\Enum\Tests\Fixtures\Enum\Permissions" name="permissions" type="int" />
+        </elao-enum:doctrine>
+    </elao-enum:config>
+</container>

--- a/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/yaml/doctrine_types.yaml
+++ b/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/yaml/doctrine_types.yaml
@@ -1,0 +1,5 @@
+elao_enum:
+    doctrine:
+        types:
+            Elao\Enum\Tests\Fixtures\Enum\Gender: gender
+            Elao\Enum\Tests\Fixtures\Enum\Permissions: { name: permissions, type: int }

--- a/tests/Unit/Bridge/Doctrine/DBAL/Types/TypesDumperTest.php
+++ b/tests/Unit/Bridge/Doctrine/DBAL/Types/TypesDumperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\DBAL\Types;
+
+use Elao\Enum\Bridge\Doctrine\DBAL\Types\TypesDumper;
+use PHPUnit\Framework\TestCase;
+
+class TypesDumperTest extends TestCase
+{
+    const FIXTURES_DIR = FIXTURES_DIR . '/Bridge/Doctrine/DBAL/Types/TypesDumperTest';
+
+    /** @var TypesDumper */
+    private $dumper;
+
+    /** @var string */
+    private $dumpPath;
+
+    protected function setUp(): void
+    {
+        $this->dumper = new TypesDumper();
+        $this->dumpPath = sys_get_temp_dir() . '/elao_enum_types_dumper.php';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dumpPath);
+    }
+
+    public function testDumpToFile()
+    {
+        $this->dumper->dumpToFile($this->dumpPath, [
+            ['Foo\Bar\Baz', 'string', 'baz'],
+            ['Foo\Bar\Qux', 'int', 'qux'],
+        ]);
+
+        self::assertFileEquals(self::FIXTURES_DIR . '/dumped_types.php', $this->dumpPath);
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineDBALTypesPassTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineDBALTypesPassTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineDBALTypesPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DoctrineDBALTypesPassTest extends TestCase
+{
+    /** @var DoctrineDBALTypesPass */
+    private $pass;
+
+    /** @var string */
+    private $dumpPath;
+
+    protected function setUp(): void
+    {
+        $this->dumpPath = sys_get_temp_dir() . '/elao_enum_types_dumper.php';
+        $this->pass = new DoctrineDBALTypesPass($this->dumpPath);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dumpPath);
+    }
+
+    public function testDoesNothingOnNoTypesSet()
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('doctrine.dbal.connection_factory', \stdClass::class);
+
+        $this->pass->process($container);
+
+        self::assertNull($def->getFile());
+        self::assertFileNotExists($this->dumpPath);
+    }
+
+    public function testDumpsOnTypesSet()
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('doctrine.dbal.connection_factory', \stdClass::class);
+        $container->getParameterBag()->set('.elao_enum.doctrine_types', [
+            ['Foo\Bar\Baz', 'string', 'baz'],
+            ['Foo\Bar\Qux', 'int', 'qux'],
+        ]);
+
+        $this->pass->process($container);
+
+        self::assertSame($this->dumpPath, $def->getFile());
+        self::assertFileExists($this->dumpPath);
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -11,7 +11,10 @@
 namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Bundle\DependencyInjection;
 
 use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Configuration;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+use Elao\Enum\Tests\Fixtures\Enum\Permissions;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends TestCase
@@ -21,10 +24,7 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), [[]]);
 
-        $this->assertEquals([
-            'argument_value_resolver' => ['enabled' => true],
-            'serializer' => ['enabled' => true],
-        ], $config);
+        $this->assertEquals($this->getDefaultConfig(), $config);
     }
 
     public function testDisabledConfig()
@@ -39,5 +39,50 @@ class ConfigurationTest extends TestCase
             'argument_value_resolver' => ['enabled' => false],
             'serializer' => ['enabled' => false],
         ], $config);
+    }
+
+    public function testDoctrineConfig()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), [[
+            'doctrine' => [
+                'types' => [
+                    Gender::class => ['name' => 'gender'],
+                    Permissions::class => ['name' => 'permissions', 'type' => 'int'],
+                ],
+            ],
+        ]]);
+
+        $this->assertEquals($this->getDefaultConfig() + [
+            'doctrine' => [
+                'types' => [
+                    Gender::class => ['name' => 'gender', 'type' => 'string'],
+                    Permissions::class => ['name' => 'permissions', 'type' => 'int'],
+                ],
+            ],
+        ], $config);
+    }
+
+    public function testDoctrineTypeConfigWithInvalidEnumClass()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "elao_enum.doctrine.types": Invalid classes ["stdClass"]. Expected instances of "Elao\Enum\EnumInterface"');
+
+        $processor = new Processor();
+        $processor->processConfiguration(new Configuration(), [[
+            'doctrine' => [
+                'types' => [
+                    \stdClass::class => ['name' => 'std'],
+                ],
+            ],
+        ]]);
+    }
+
+    private function getDefaultConfig(): array
+    {
+        return [
+            'argument_value_resolver' => ['enabled' => true],
+            'serializer' => ['enabled' => true],
+        ];
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,9 +17,12 @@ use Symfony\Component\Filesystem\Filesystem;
 
 date_default_timezone_set('UTC');
 
-$loader = require __DIR__ . '/../../../../vendor/autoload.php';
+$loader = require __DIR__ . '/../vendor/autoload.php';
 
-require __DIR__ . '/src/AppKernel.php';
+const FIXTURES_DIR = __DIR__ . '/Fixtures';
+
+// Prepare integration tests:
+require __DIR__ . '/Fixtures/Integration/Symfony/src/AppKernel.php';
 
 // Empty generated symfony cache
 (new Filesystem())->remove(__DIR__ . '/var/cache');


### PR DESCRIPTION
This is kind of an experimental feature I'd like to put on practice: don't require the developper to write its DBAL type for enums.
Just indicate the types in config, and the bundle will generate+register these:

```yaml
elao_enum:
    doctrine:
        types:
            App\Enum\GenderEnum: gender
            App\Enum\Permissions: { name: permissions, type: int } # values are stored as integers
```
