### PR TITLE
group generated type class by namespace

### DIFF
--- a/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
+++ b/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
@@ -24,41 +24,55 @@ class TypesDumper
 
     private function dump(array $types): string
     {
+        $namespaces = [];
+        foreach ($types as [$enumClass, $type, $name]) {
+            $fqcn = self::getTypeClassname($enumClass);
+            $classname = basename(str_replace('\\', '/', $fqcn));
+            $ns = substr($fqcn, 0, -\strlen($classname) - 1);
+
+            if (!isset($namespaces[$ns])) {
+                $namespaces[$ns] = '';
+            }
+
+            $namespaces[$ns] .= $this->getTypeCode($fqcn, $classname, $enumClass, $type, $name);
+        }
+
         $code = "<?php\n";
-        foreach ($types as [$class, $type, $name]) {
-            $code .= $this->getTypeCode($class, $type, $name);
+        foreach ($namespaces as $namespace => $typeCode) {
+            $code .= <<<PHP
+
+namespace $namespace {
+$typeCode
+}
+
+PHP;
         }
 
         return $code;
     }
 
-    private function getTypeCode(string $class, string $type, string $name): string
+    private function getTypeCode(string $fqcn, string $classname, string $enumClass, string $type, string $name): string
     {
         $baseClass = $type === 'int' ? AbstractIntegerEnumType::class : AbstractEnumType::class;
-        $fqcn = self::getTypeClassname($class);
-        $classname = basename(str_replace('\\', '/', $fqcn));
-        $ns = substr($fqcn, 0, -\strlen($classname) - 1);
 
         return <<<PHP
 
-namespace $ns;
-
-if (!\class_exists('\\$fqcn')) {
-    class $classname extends \\{$baseClass}
-    {
-        const NAME = '$name';
-
-        protected function getEnumClass(): string
+    if (!\class_exists(\\$fqcn::class)) {
+        class $classname extends \\{$baseClass}
         {
-            return \\{$class}::class;
-        }
+            const NAME = '$name';
 
-        public function getName(): string
-        {
-            return static::NAME;
+            protected function getEnumClass(): string
+            {
+                return \\{$enumClass}::class;
+            }
+
+            public function getName(): string
+            {
+                return static::NAME;
+            }
         }
     }
-}
 
 PHP;
     }

--- a/tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest/dumped_types.php
+++ b/tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest/dumped_types.php
@@ -1,39 +1,60 @@
 <?php
 
-namespace ELAO_ENUM_DT\Foo\Bar;
+namespace ELAO_ENUM_DT\Foo\Bar {
 
-if (!\class_exists('\ELAO_ENUM_DT\Foo\Bar\BazType')) {
-    class BazType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
-    {
-        const NAME = 'baz';
-
-        protected function getEnumClass(): string
+    if (!\class_exists(\ELAO_ENUM_DT\Foo\Bar\BazType::class)) {
+        class BazType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
         {
-            return \Foo\Bar\Baz::class;
-        }
+            const NAME = 'baz';
 
-        public function getName(): string
-        {
-            return static::NAME;
+            protected function getEnumClass(): string
+            {
+                return \Foo\Bar\Baz::class;
+            }
+
+            public function getName(): string
+            {
+                return static::NAME;
+            }
         }
     }
+
+    if (!\class_exists(\ELAO_ENUM_DT\Foo\Bar\QuxType::class)) {
+        class QuxType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractIntegerEnumType
+        {
+            const NAME = 'qux';
+
+            protected function getEnumClass(): string
+            {
+                return \Foo\Bar\Qux::class;
+            }
+
+            public function getName(): string
+            {
+                return static::NAME;
+            }
+        }
+    }
+
 }
 
-namespace ELAO_ENUM_DT\Foo\Bar;
+namespace ELAO_ENUM_DT\Foo\Baz {
 
-if (!\class_exists('\ELAO_ENUM_DT\Foo\Bar\QuxType')) {
-    class QuxType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractIntegerEnumType
-    {
-        const NAME = 'qux';
-
-        protected function getEnumClass(): string
+    if (!\class_exists(\ELAO_ENUM_DT\Foo\Baz\FooType::class)) {
+        class FooType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractIntegerEnumType
         {
-            return \Foo\Bar\Qux::class;
-        }
+            const NAME = 'foo';
 
-        public function getName(): string
-        {
-            return static::NAME;
+            protected function getEnumClass(): string
+            {
+                return \Foo\Baz\Foo::class;
+            }
+
+            public function getName(): string
+            {
+                return static::NAME;
+            }
         }
     }
+
 }

--- a/tests/Unit/Bridge/Doctrine/DBAL/Types/TypesDumperTest.php
+++ b/tests/Unit/Bridge/Doctrine/DBAL/Types/TypesDumperTest.php
@@ -39,6 +39,7 @@ class TypesDumperTest extends TestCase
         $this->dumper->dumpToFile($this->dumpPath, [
             ['Foo\Bar\Baz', 'string', 'baz'],
             ['Foo\Bar\Qux', 'int', 'qux'],
+            ['Foo\Baz\Foo', 'int', 'foo'],
         ]);
 
         self::assertFileEquals(self::FIXTURES_DIR . '/dumped_types.php', $this->dumpPath);


### PR DESCRIPTION
this syntax is not recommended for combining namespaces into a single file. Instead it is recommended to use the alternate bracketed syntax.  (source: https://www.php.net/manual/en/language.namespaces.definitionmultiple.php)

Before
```php
<?php

namespace ELAO_ENUM_DT\App\Enum;

if (!\class_exists('\ELAO_ENUM_DT\App\Enum\GenderType')) {
    class GenderType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
    {
        const NAME = 'gender';

        protected function getEnumClass(): string
        {
            return \App\Enum\Gender::class;
        }

        public function getName(): string
        {
            return static::NAME;
        }
    }
}

namespace ELAO_ENUM_DT\App\AnotherEnum;

if (!\class_exists('\ELAO_ENUM_DT\App\AnotherEnum\FooType')) {
    class FooType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
    {
        const NAME = 'foo';

        protected function getEnumClass(): string
        {
            return \App\AnotherEnum\Foo::class;
        }

        public function getName(): string
        {
            return static::NAME;
        }
    }
}

namespace ELAO_ENUM_DT\App\Enum;

if (!\class_exists('\ELAO_ENUM_DT\App\Enum\BazType')) {
    class BazType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractIntegerEnumType
    {
        const NAME = 'baz';

        protected function getEnumClass(): string
        {
            return \App\Enum\Baz::class;
        }

        public function getName(): string
        {
            return static::NAME;
        }
    }
}

```

After
```php
<?php

namespace ELAO_ENUM_DT\App\Enum {

    if (!\class_exists(\ELAO_ENUM_DT\App\Enum\GenderType::class)) {
        class GenderType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
        {
            const NAME = 'gender';

            protected function getEnumClass(): string
            {
                return \App\Enum\Gender::class;
            }

            public function getName(): string
            {
                return static::NAME;
            }
        }
    }

    if (!\class_exists(\ELAO_ENUM_DT\App\Enum\BazType::class)) {
        class BazType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractIntegerEnumType
        {
            const NAME = 'baz';

            protected function getEnumClass(): string
            {
                return \App\Enum\Baz::class;
            }

            public function getName(): string
            {
                return static::NAME;
            }
        }
    }

}

namespace ELAO_ENUM_DT\App\AnotherEnum {

    if (!\class_exists(\ELAO_ENUM_DT\App\AnotherEnum\FooType::class)) {
        class FooType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
        {
            const NAME = 'foo';

            protected function getEnumClass(): string
            {
                return \App\AnotherEnum\Foo::class;
            }

            public function getName(): string
            {
                return static::NAME;
            }
        }
    }

}
```

