### PR TITLE
add ApiPlatform ElaoEnum schema type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ before_install:
   - if [[ "$ENABLE_CODE_COVERAGE" != "yes" ]]; then phpenv config-rm xdebug.ini || true; fi;
   - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [[ "$CHECK_CODE_STYLE" != "yes" ]]; then composer remove "friendsofphp/php-cs-fixer" --no-update --no-interaction --dev; fi;
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then composer remove "api-platform/core" --no-update --no-interaction --dev; fi;
 
 install:
   - composer update --prefer-dist --no-interaction --optimize-autoloader --prefer-stable --no-progress $COMPOSER_FLAGS

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Table of Contents
     * [Symfony VarDumper component](#symfony-vardumper-component)
     * [Faker](#faker)
       * [Usage with Alice](#usage-with-alice)
+    * [Api-Platform](#api-platform)
+      * [OpenApi / Swagger](#OpenApi-/-Swagger)
   * [API](#api)
     * [Simple enum](#simple-enum)
     * [Readable enum](#readable-enum)
@@ -865,6 +867,11 @@ MyEntity:
 ```
 
 > 📝 `MISTER` in `<enum(Civility::MISTER)>` refers to a constant defined in the `Civility` enum class, not to a constant's value ('mister' string for instance).
+
+## Api-Platform
+
+### OpenApi / Swagger
+The PhpEnums library provides an `Elao\Enum\Bridge\ApiPlatform\Core\JsonSchema\Type\ElaoEnumType` to generate a OpenApi (formally Swagger) documentation based on your enums. This decorator is automatically wired for you when using this library. 
 
 # API
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "php": ">=7.0"
     },
     "require-dev": {
+        "api-platform/core": "^2.5.1",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/doctrine-bundle": "^1.4|^2.0",
         "doctrine/orm": "^2.4",

--- a/src/Bridge/ApiPlatform/Core/JsonSchema/Type/ElaoEnumType.php
+++ b/src/Bridge/ApiPlatform/Core/JsonSchema/Type/ElaoEnumType.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\ApiPlatform\Core\JsonSchema\Type;
+
+use ApiPlatform\Core\JsonSchema\Schema;
+use ApiPlatform\Core\JsonSchema\TypeFactoryInterface;
+use Elao\Enum\EnumInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+final class ElaoEnumType implements TypeFactoryInterface
+{
+    /**
+     * @var TypeFactoryInterface
+     */
+    private $decorated;
+
+    public function __construct(TypeFactoryInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(Type $type, string $format = 'json', ?bool $readableLink = null, ?array $serializerContext = null, Schema $schema = null): array
+    {
+        if (!is_a($enumClass = $type->getClassName(), EnumInterface::class, true)) {
+            return $this->decorated->getType($type, $format, $readableLink, $serializerContext, $schema);
+        }
+
+        $values = $enumClass::values();
+
+        return [
+            'type' => 'string',
+            'enum' => $values,
+            'example' => $values[0],
+        ];
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension.php
@@ -10,6 +10,8 @@
 
 namespace Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection;
 
+use ApiPlatform\Core\JsonSchema\TypeFactory;
+use Elao\Enum\Bridge\ApiPlatform\Core\JsonSchema\Type\ElaoEnumType;
 use Elao\Enum\Bridge\Doctrine\DBAL\Types\TypesDumper;
 use Elao\Enum\Bridge\Symfony\HttpKernel\Controller\ArgumentResolver\EnumValueResolver;
 use Elao\Enum\Bridge\Symfony\Serializer\Normalizer\EnumNormalizer;
@@ -67,6 +69,10 @@ class ElaoEnumExtension extends Extension implements PrependExtensionInterface
             $container->removeDefinition(EnumExtractor::class);
         } else {
             $this->registerTranslationExtractorConfiguration($config['translation_extractor'], $container);
+        }
+
+        if (!class_exists(TypeFactory::class)) {
+            $container->removeDefinition(ElaoEnumType::class);
         }
 
         if ($types = $config['doctrine']['types'] ?? false) {

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.xml
@@ -22,5 +22,9 @@
             <argument /> <!-- Ignore paths/files -->
             <tag name="translation.extractor" alias="elao_enum" />
         </service>
+
+        <service id="Elao\Enum\Bridge\ApiPlatform\Core\JsonSchema\Type\ElaoEnumType" decorates="api_platform.json_schema.type_factory">
+            <argument type="service" id="Elao\Enum\Bridge\ApiPlatform\Core\JsonSchema\Type\ElaoEnumType.inner" />
+        </service>
     </services>
 </container>

--- a/tests/Unit/Bridge/ApiPlatform/Core/JsonSchema/Type/ElaoEnumTypeTest.php
+++ b/tests/Unit/Bridge/ApiPlatform/Core/JsonSchema/Type/ElaoEnumTypeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\ApiPlatform\Core\JsonSchema\Type;
+
+use ApiPlatform\Core\JsonSchema\TypeFactory;
+use Elao\Enum\Bridge\ApiPlatform\Core\JsonSchema\Type\ElaoEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @requires PHP >= 7.1
+ */
+class ElaoEnumTypeTest extends TestCase
+{
+    /**
+     * @dataProvider typeProvider
+     */
+    public function testGetType(array $expected, Type $type): void
+    {
+        $typeFactory = new ElaoEnumType(new TypeFactory());
+        $this->assertEquals($expected, $typeFactory->getType($type, 'json'));
+    }
+
+    public function typeProvider(): iterable
+    {
+        yield [
+            [
+                'type' => 'string',
+                'enum' => [
+                    0 => 'unknown',
+                    1 => 'male',
+                    2 => 'female',
+                ],
+                'example' => 'unknown',
+            ],
+            new Type(Type::BUILTIN_TYPE_OBJECT, true, Gender::class),
+        ];
+        yield [['type' => 'integer'], new Type(Type::BUILTIN_TYPE_INT)];
+    }
+}


### PR DESCRIPTION
This PR adds a class that decorates the ApiPlatform TypeFactory to support the documentation of elao/PhpEnums when generating the swagger ui.

Before :
![enum-before](https://user-images.githubusercontent.com/34127121/80078697-906a0800-854f-11ea-8e54-99e568a4bed9.PNG)

After:
![enum-after](https://user-images.githubusercontent.com/34127121/80078764-a2e44180-854f-11ea-9079-522ad2e30e9d.PNG)