### PR TITLE
Fix return type for Enum::instances()

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -104,6 +104,8 @@ abstract class Enum implements EnumInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return static[]
      */
     public static function instances(): array
     {


### PR DESCRIPTION
Hi Elao team!

We are switching from `myclabs/php-enum` to your package because of your great integration with symfony (mostly DBAL types and serializer).

It seems that the return type of the `Enum::instances()` method does not suit well for our dear friend phpstan :D

I suppose this is not done on purpose since an override of the return type has been done for the `::get()` method:
`EnumInterface::get(): EnumInterface` -> `Enum::get(): static`

So I suggest to do the same with the `Enum::instances()` method.

Cheers, and gros poutous
