### PR TITLE
fixing Windows tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
             allow-unstable: true
       fail-fast: false
     steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Elao Enumerations
 [![Latest Stable Version](https://poser.pugx.org/elao/enum/v/stable?format=flat-square)](https://packagist.org/packages/elao/enum) 
 [![Total Downloads](https://poser.pugx.org/elao/enum/downloads?format=flat-square)](https://packagist.org/packages/elao/enum) 
 [![Monthly Downloads](https://poser.pugx.org/elao/enum/d/monthly?format=flat-square)](https://packagist.org/packages/elao/enum)
-[![Build Status](https://img.shields.io/travis/Elao/PhpEnums/master.svg?style=flat-square)](https://travis-ci.org/Elao/PhpEnums)
+[![Tests](https://github.com/Elao/PhpEnums/actions/workflows/tests.yml/badge.svg)](https://github.com/Elao/PhpEnums/actions/workflows/tests.yml)
 [![Coveralls](https://img.shields.io/coveralls/Elao/PhpEnums.svg?style=flat-square)](https://coveralls.io/github/Elao/PhpEnums)
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/Elao/PhpEnums.svg?style=flat-square)](https://scrutinizer-ci.com/g/Elao/PhpEnums/?branch=master)
 [![php](https://img.shields.io/badge/PHP-7.3-green.svg?style=flat-square "Available for PHP 7.3+")](http://php.net)

--- a/tests/Unit/Bridge/Doctrine/DBAL/Types/TypesDumperTest.php
+++ b/tests/Unit/Bridge/Doctrine/DBAL/Types/TypesDumperTest.php
@@ -13,9 +13,6 @@ namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\DBAL\Types;
 use Elao\Enum\Bridge\Doctrine\DBAL\Types\TypesDumper;
 use Elao\Enum\Tests\TestCase;
 
-/**
- * @requires OS Linux|Darwin
- */
 class TypesDumperTest extends TestCase
 {
     public const FIXTURES_DIR = FIXTURES_DIR . '/Bridge/Doctrine/DBAL/Types/TypesDumperTest';

--- a/tests/Unit/Bridge/Symfony/VarDumper/Caster/EnumCasterTest.php
+++ b/tests/Unit/Bridge/Symfony/VarDumper/Caster/EnumCasterTest.php
@@ -23,9 +23,6 @@ use Symfony\Component\VarDumper\Dumper\AbstractDumper;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 
-/**
- * @requires OS Linux|Darwin
- */
 class EnumCasterTest extends TestCase
 {
     use VarDumperTestTrait;

--- a/tests/Unit/JsDumper/JsDumperTest.php
+++ b/tests/Unit/JsDumper/JsDumperTest.php
@@ -127,7 +127,6 @@ class JsDumperTest extends TestCase
 
     /**
      * @dataProvider provide testDumpEnumClass data
-     * @requires OS Linux|Darwin
      */
     public function testDumpEnumClass(string $enumClass, string $expectationFilePath): void
     {


### PR DESCRIPTION
Turned out, setting git LF settings fixed the issue as by default, Windows runner's git is converting LF to CRLF while checking out the code, resulting invalid data to be produced. This PR solves this issue #134 