### PR TITLE
improve return types phpdocs

### DIFF
--- a/src/AutoDiscoveredValuesTrait.php
+++ b/src/AutoDiscoveredValuesTrait.php
@@ -24,9 +24,12 @@ trait AutoDiscoveredValuesTrait
     private static $guessedReadables = [];
 
     /**
+     * @template T of int|string
+     *
      * @see EnumInterface::values()
      *
      * @return int[]|string[]
+     * @psalm-return list<T>
      */
     public static function values(): array
     {
@@ -116,6 +119,7 @@ trait AutoDiscoveredValuesTrait
      * E.g: `return [static::class, DumbEnum::class];` to discover values from DumbEnum as well.
      *
      * @return string[]
+     * @psalm-return class-string[]
      */
     protected static function getDiscoveredClasses(): array
     {

--- a/src/Bridge/Symfony/Console/Command/DumpJsEnumsCommand.php
+++ b/src/Bridge/Symfony/Console/Command/DumpJsEnumsCommand.php
@@ -10,6 +10,7 @@
 
 namespace Elao\Enum\Bridge\Symfony\Console\Command;
 
+use Elao\Enum\EnumInterface;
 use Elao\Enum\JsDumper\JsDumper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/ChoiceEnumTrait.php
+++ b/src/ChoiceEnumTrait.php
@@ -25,7 +25,10 @@ trait ChoiceEnumTrait
     /**
      * @see EnumInterface::values()
      *
+     * @template T of int|string
+     *
      * @return int[]|string[]
+     * @psalm-return list<T>
      */
     public static function values(): array
     {
@@ -45,7 +48,11 @@ trait ChoiceEnumTrait
     /**
      * @see ReadableEnumInterface::readables()
      *
-     * @return string[] labels indexed by enumerated value
+     * @template T of int|string
+     *
+     * @return array<int|string, string> labels indexed by enumerated value
+     *
+     * @psalm-return array<T, string>
      */
     public static function readables(): array
     {
@@ -55,7 +62,11 @@ trait ChoiceEnumTrait
     }
 
     /**
-     * @return string[] The enumerated values as keys and their labels as values.
+     * @template T of int|string
+     *
+     * @return array<int|string, string> The enumerated values as keys and their labels as values.
+     *
+     * @psalm-return array<T, string>
      */
     abstract protected static function choices(): array;
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -13,6 +13,10 @@ namespace Elao\Enum;
 use Elao\Enum\Exception\InvalidValueException;
 use Elao\Enum\Exception\LogicException;
 
+/**
+ * @template T of int|string
+ * @implements EnumInterface<T>
+ */
 abstract class Enum implements EnumInterface
 {
     /**
@@ -20,11 +24,14 @@ abstract class Enum implements EnumInterface
      * This cache is used in order to make single enums values act as singletons.
      * This means you'll always get the exact same instance for a same enum value.
      *
-     * @var array
+     * @var EnumInterface<int|string>[]
      */
     private static $instances;
 
-    /** @var mixed */
+    /**
+     * @var int|string
+     * @psalm-var T
+     */
     protected $value;
 
     /**

--- a/src/EnumInterface.php
+++ b/src/EnumInterface.php
@@ -12,10 +12,16 @@ namespace Elao\Enum;
 
 use Elao\Enum\Exception\InvalidValueException;
 
+/**
+ * @template T of int|string
+ */
 interface EnumInterface
 {
     /**
+     * @template T of int|string
+     *
      * @param int|string $value The value of a particular enumerated constant
+     * @psalm-param T $value
      *
      * @throws InvalidValueException When $value is not acceptable for this enumeration type
      *
@@ -26,12 +32,18 @@ interface EnumInterface
     /**
      * Returns any possible value for the enumeration.
      *
-     * @return int[]|string[]
+     * @template T of int|string
+     *
+     * @return list<int|string>
+     * @psalm-return list<T>
      */
     public static function values(): array;
 
     /**
+     * @template T of int|string
+     *
      * @param int|string $value
+     * @psalm-param  T $value
      *
      * @return bool True if the value is acceptable for this enumeration
      */
@@ -48,13 +60,14 @@ interface EnumInterface
      * Gets the raw value.
      *
      * @return int|string
+     * @psalm-return T
      */
     public function getValue();
 
     /**
      * Determines whether two enumerations instances should be considered the same.
      *
-     * @param EnumInterface $enum An enum object to compare with this instance
+     * @param EnumInterface<int|string> $enum An enum object to compare with this instance
      */
     public function equals(EnumInterface $enum): bool;
 

--- a/src/FlaggedEnum.php
+++ b/src/FlaggedEnum.php
@@ -13,14 +13,17 @@ namespace Elao\Enum;
 use Elao\Enum\Exception\InvalidValueException;
 use Elao\Enum\Exception\LogicException;
 
+/**
+ * @extends ReadableEnum<int>
+ */
 abstract class FlaggedEnum extends ReadableEnum
 {
     public const NONE = 0;
 
-    /** @var array */
+    /** @var array<class-string<FlaggedEnum>, int> */
     private static $masks = [];
 
-    /** @var array */
+    /** @var array<class-string<FlaggedEnum>, array<int, string>> */
     private static $readables = [];
 
     /** @var int[] */

--- a/src/JsDumper/JsDumper.php
+++ b/src/JsDumper/JsDumper.php
@@ -10,6 +10,7 @@
 
 namespace Elao\Enum\JsDumper;
 
+use Elao\Enum\EnumInterface;
 use Elao\Enum\FlaggedEnum;
 use Elao\Enum\ReadableEnumInterface;
 use Symfony\Component\Filesystem\Filesystem;

--- a/src/ReadableEnum.php
+++ b/src/ReadableEnum.php
@@ -12,6 +12,11 @@ namespace Elao\Enum;
 
 use Elao\Enum\Exception\InvalidValueException;
 
+/**
+ * @template T of int|string
+ * @extends Enum<T>
+ * @implements ReadableEnumInterface<T>
+ */
 abstract class ReadableEnum extends Enum implements ReadableEnumInterface
 {
     /**

--- a/src/ReadableEnumInterface.php
+++ b/src/ReadableEnumInterface.php
@@ -12,19 +12,29 @@ namespace Elao\Enum;
 
 use Elao\Enum\Exception\InvalidValueException;
 
+/**
+ * @template T of int|string
+ * @implements EnumInterface<T>
+ */
 interface ReadableEnumInterface extends EnumInterface
 {
     /**
      * Gets an array of the human representations indexed by possible values.
      *
+     * @template T of int|string
+     *
      * @return string[] labels indexed by enumerated value
+     * @psalm-return array<T, string>
      */
     public static function readables(): array;
 
     /**
      * Gets the human representation for a given value.
      *
-     * @param mixed $value The value of a particular enumerated constant
+     * @template T of int|string
+     *
+     * @param int|string $value The value of a particular enumerated constant
+     * @psalm-param T $value
      *
      * @throws InvalidValueException When $value is not acceptable for this enumeration type
      *

--- a/src/SimpleChoiceEnum.php
+++ b/src/SimpleChoiceEnum.php
@@ -16,6 +16,9 @@ namespace Elao\Enum;
  * - auto-discovers enumerated values from public constants.
  * - implements {@link \Elao\Enum\ReadableEnumInterface} with default labels
  *   identical to enumerated values's constant name.
+ *
+ * @template T of int|string
+ * @extends ReadableEnum<T>
  */
 abstract class SimpleChoiceEnum extends ReadableEnum
 {


### PR DESCRIPTION
Some of the return types were incorrect, missing the template `T` or missing an import.