### PR TITLE
Add Doctrine ODM bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
           - name: 'Test latest Symfony [Linux, PHP 7.3]'
             os: 'ubuntu-latest'
             php: '7.3'
-            composer-flags: '--prefer-lowest'
 
           - name: 'Test latest Symfony [Linux, PHP 7.4]'
             os: 'ubuntu-latest'
@@ -77,7 +76,7 @@ jobs:
             php: '8.0'
             code-coverage: true
 
-          - name: 'Test latest Symfony [Window, PHP 8.0]'
+          - name: 'Test latest Symfony [Windows, PHP 8.0]'
             os: 'windows-latest'
             php: '8.0'
 
@@ -85,7 +84,7 @@ jobs:
           - name: 'Test Next Symfony [Linux, PHP 8.1] (allowed failure)'
             os: 'ubuntu-latest'
             php: '8.1'
-            symfony-version: '^5.4'
+            symfony-version: '^5.4@dev'
             composer-flags: '--ignore-platform-req php'
             allow-unstable: true
             allow-failure: true
@@ -104,7 +103,17 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
-          extensions: pdo_sqlite
+          extensions: pdo_sqlite, mongodb
+
+      - name: Start MongoDB (Linux)
+        uses: supercharge/mongodb-github-action@1.6.0
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+
+      - name: Start MongoDB (Windows)
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install mongodb
+        if: ${{ matrix.os == 'windows-latest' }}
 
       - name: 'Get composer cache directory'
         id: composer-cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,6 +12,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude('tests/Fixtures/Integration/Symfony/var')
     ->exclude('tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest')
+    ->exclude('tests/Fixtures/Bridge/Doctrine/ODM/Types/TypesDumperTest')
     // Excluded until php-cs-fixer supports PHP 8 attributes:
     ->notPath('src/Bridge/Symfony/Validator/Constraint/Enum.php')
     ->notPath('tests/Fixtures/Bridge/Symfony/Validator/Constraint/ObjectWithEnumChoiceAsPhpAttribute.php')

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         }
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
     "require": {
         "php": ">=7.3"
     },
@@ -48,6 +47,8 @@
         "doctrine/data-fixtures": "^1.2",
         "doctrine/doctrine-bundle": "^1.12|^2.0",
         "doctrine/orm": "^2.4",
+        "doctrine/mongodb-odm-bundle": "^4.2",
+        "doctrine/mongodb-odm": "^2.1",
         "friendsofphp/php-cs-fixer": "^3.0",
         "nelmio/alice": "^3.0",
         "symfony/browser-kit": "^4.4|^5.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,10 +10,12 @@
     </include>
   </coverage>
   <php>
-    <server name="KERNEL_CLASS" value="AppKernel"/>
+    <server name="KERNEL_CLASS" value="App\Kernel"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0&amp;max[total]=9999&amp;verbose=1"/>
     <env name="SYMFONY_PHPUNIT_REQUIRE" value="phpspec/prophecy-phpunit"/>
     <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>
+    <env name="MONGODB_URL" value="mongodb://localhost:27017" />
+    <env name="MONGODB_DB" value="enum-test" />
   </php>
   <testsuites>
     <testsuite name="Elao Enumerations Test Suite">

--- a/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
+++ b/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\Common;
+
+abstract class AbstractTypesDumper
+{
+    public function dumpToFile(string $file, array $types)
+    {
+        file_put_contents($file, $this->dump($types));
+    }
+
+    public static function getTypeClassname(string $class, string $type): string
+    {
+        return sprintf('%s\\%s%s', static::getMarker(), $class, static::getSuffixes()[$type]);
+    }
+
+    protected function dump(array $types): string
+    {
+        $namespaces = [];
+        foreach ($types as [$enumClass, $type, $name]) {
+            $fqcn = self::getTypeClassname($enumClass, $type);
+            $classname = basename(str_replace('\\', '/', $fqcn));
+            $ns = substr($fqcn, 0, -\strlen($classname) - 1);
+
+            if (!isset($namespaces[$ns])) {
+                $namespaces[$ns] = '';
+            }
+
+            $namespaces[$ns] .= $this->getTypeCode($classname, $enumClass, $type, $name);
+        }
+
+        $code = "<?php\n";
+        foreach ($namespaces as $namespace => $typeCode) {
+            $code .= <<<PHP
+
+namespace $namespace {
+$typeCode
+}
+
+PHP;
+        }
+
+        return $code;
+    }
+
+    abstract protected function getTypeCode(string $classname, string $enumClass, string $type, string $name): string;
+
+    abstract protected static function getSuffixes(): array;
+
+    abstract protected static function getMarker(): string;
+}

--- a/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
+++ b/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
@@ -10,12 +10,13 @@
 
 namespace Elao\Enum\Bridge\Doctrine\DBAL\Types;
 
+use Elao\Enum\Bridge\Doctrine\Common\AbstractTypesDumper;
 use Elao\Enum\Exception\LogicException;
 
 /**
  * @internal
  */
-class TypesDumper
+class TypesDumper extends AbstractTypesDumper
 {
     public const TYPE_INT = 'int';
     public const TYPE_STRING = 'string';
@@ -30,51 +31,7 @@ class TypesDumper
         self::TYPE_CSV_COLLECTION,
     ];
 
-    public const TYPES_SUFFIXES = [
-        self::TYPE_INT => 'Type',
-        self::TYPE_STRING => 'Type',
-        self::TYPE_ENUM => 'Type',
-        self::TYPE_JSON_COLLECTION => 'JsonCollectionType',
-        self::TYPE_CSV_COLLECTION => 'CsvCollectionType',
-    ];
-
-    public const MARKER = 'ELAO_ENUM_DT';
-
-    public function dumpToFile(string $file, array $types)
-    {
-        file_put_contents($file, $this->dump($types));
-    }
-
-    private function dump(array $types): string
-    {
-        $namespaces = [];
-        foreach ($types as [$enumClass, $type, $name]) {
-            $fqcn = self::getTypeClassname($enumClass, $type);
-            $classname = basename(str_replace('\\', '/', $fqcn));
-            $ns = substr($fqcn, 0, -\strlen($classname) - 1);
-
-            if (!isset($namespaces[$ns])) {
-                $namespaces[$ns] = '';
-            }
-
-            $namespaces[$ns] .= $this->getTypeCode($classname, $enumClass, $type, $name);
-        }
-
-        $code = "<?php\n";
-        foreach ($namespaces as $namespace => $typeCode) {
-            $code .= <<<PHP
-
-namespace $namespace {
-$typeCode
-}
-
-PHP;
-        }
-
-        return $code;
-    }
-
-    private function getTypeCode(string $classname, string $enumClass, string $type, string $name): string
+    protected function getTypeCode(string $classname, string $enumClass, string $type, string $name): string
     {
         switch ($type) {
             case self::TYPE_INT:
@@ -118,10 +75,19 @@ PHP;
 PHP;
     }
 
-    public static function getTypeClassname(string $class, string $type): string
+    protected static function getSuffixes(): array
     {
-        $suffix = self::TYPES_SUFFIXES[$type];
+        return [
+            self::TYPE_INT => 'Type',
+            self::TYPE_STRING => 'Type',
+            self::TYPE_ENUM => 'Type',
+            self::TYPE_JSON_COLLECTION => 'JsonCollectionType',
+            self::TYPE_CSV_COLLECTION => 'CsvCollectionType',
+        ];
+    }
 
-        return self::MARKER . "\\{$class}{$suffix}";
+    protected static function getMarker(): string
+    {
+        return 'ELAO_ENUM_DT_DBAL';
     }
 }

--- a/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
+++ b/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\ODM\Types;
+
+use Doctrine\ODM\MongoDB\Types\CollectionType;
+use Elao\Enum\EnumInterface;
+
+/**
+ * @template TEnum of EnumInterface
+ */
+abstract class AbstractCollectionEnumType extends CollectionType
+{
+    public function convertToDatabaseValue($value)
+    {
+        if (\is_array($value)) {
+            return array_unique(array_values(array_map(static function ($value) {
+                return $value instanceof EnumInterface ? $value->getValue() : $value;
+            }, $value)));
+        }
+
+        return parent::convertToDatabaseValue($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @phpstan-return array<TEnum>|null
+     */
+    public function convertToPHPValue($value)
+    {
+        $values = parent::convertToPHPValue($value);
+
+        if (\is_array($values)) {
+            $enumClass = $this->getEnumClass();
+            $values = array_map([$enumClass, 'get'], array_map(static function ($v) use ($enumClass) {
+                // Attempt to cast to integer value if the enum class accepts it:
+                return $enumClass::accepts((int) $v) ? (int) $v : $v;
+            }, array_unique(array_values($values))));
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return class-string<TEnum>
+     */
+    abstract protected function getEnumClass(): string;
+}

--- a/src/Bridge/Doctrine/ODM/Types/AbstractEnumType.php
+++ b/src/Bridge/Doctrine/ODM/Types/AbstractEnumType.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\ODM\Types;
+
+use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Elao\Enum\EnumInterface;
+
+/**
+ * @template TEnum of EnumInterface
+ */
+abstract class AbstractEnumType extends Type
+{
+    use ClosureToPHP;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value)
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $class = static::getEnumClass();
+
+        if ($value instanceof $class) {
+            return $value->getValue();
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @phpstan-return TEnum
+     */
+    public function convertToPHPValue($value): ?EnumInterface
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $class = $this->getEnumClass();
+
+        return $class::get($value);
+    }
+
+    /**
+     * @return class-string<TEnum>
+     */
+    abstract protected function getEnumClass(): string;
+}

--- a/src/Bridge/Doctrine/ODM/Types/TypesDumper.php
+++ b/src/Bridge/Doctrine/ODM/Types/TypesDumper.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\Common\AbstractTypesDumper;
+use Elao\Enum\Exception\LogicException;
+
+/**
+ * @internal
+ */
+class TypesDumper extends AbstractTypesDumper
+{
+    public const TYPE_SINGLE = 'single';
+    public const TYPE_COLLECTION = 'collection';
+    public const TYPES = [
+        self::TYPE_SINGLE,
+        self::TYPE_COLLECTION,
+    ];
+
+    protected function getTypeCode(string $classname, string $enumClass, string $type, string $name): string
+    {
+        switch ($type) {
+            case self::TYPE_SINGLE:
+                $baseClass = AbstractEnumType::class;
+                break;
+            case self::TYPE_COLLECTION:
+                $baseClass = AbstractCollectionEnumType::class;
+                break;
+            default:
+                throw new LogicException(sprintf('Unexpected type "%s"', $type));
+        }
+
+        return <<<PHP
+
+    if (!\class_exists($classname::class)) {
+        class $classname extends \\{$baseClass}
+        {
+            protected function getEnumClass(): string
+            {
+                return \\{$enumClass}::class;
+            }
+        }
+    }
+
+PHP;
+    }
+
+    protected static function getSuffixes(): array
+    {
+        return [
+            self::TYPE_SINGLE => 'Type',
+            self::TYPE_COLLECTION => 'CollectionType',
+        ];
+    }
+
+    protected static function getMarker(): string
+    {
+        return 'ELAO_ENUM_DT_ODM';
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\TypesDumper;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DoctrineODMTypesPass implements CompilerPassInterface
+{
+    /** @var string */
+    private $typesFilePath;
+
+    public function __construct(string $typesFilePath)
+    {
+        $this->typesFilePath = $typesFilePath;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('.elao_enum.doctrine_mongodb_types')) {
+            return;
+        }
+
+        $types = $container->getParameter('.elao_enum.doctrine_mongodb_types');
+
+        (new TypesDumper())->dumpToFile($this->typesFilePath, $types);
+
+        if (!empty($types)) {
+            $configuratorDefinition = $container->getDefinition('doctrine_mongodb.odm.manager_configurator.abstract');
+            $configuratorDefinition->setFile($this->typesFilePath);
+        }
+    }
+}

--- a/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
+++ b/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
@@ -11,17 +11,21 @@
 namespace Elao\Enum\Bridge\Symfony\Bundle;
 
 use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineDBALTypesPass;
+use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineODMTypesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ElaoEnumBundle extends Bundle
 {
-    public const DOCTRINE_TYPES_FILENAME = 'elao_enum_doctrine_types.php';
-
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
 
-        $container->addCompilerPass(new DoctrineDBALTypesPass($container->getParameter('kernel.cache_dir') . '/' . self::DOCTRINE_TYPES_FILENAME));
+        $container->addCompilerPass(
+            new DoctrineDBALTypesPass($container->getParameter('kernel.cache_dir') . '/elao_enum_doctrine_dbal_types.php')
+        );
+        $container->addCompilerPass(
+            new DoctrineODMTypesPass($container->getParameter('kernel.cache_dir') . '/elao_enum_doctrine_odm_types.php')
+        );
     }
 }

--- a/src/Bridge/Symfony/Bundle/Resources/config/schema/elao_enum.xsd
+++ b/src/Bridge/Symfony/Bundle/Resources/config/schema/elao_enum.xsd
@@ -12,6 +12,7 @@
             <xsd:element name="serializer" type="serializer" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="argument_value_resolver" type="argument_value_resolver" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="doctrine" type="doctrine" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="doctrine_mongodb" type="doctrine_mongodb" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="translation_extractor" type="translation_extractor" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="js" type="js" minOccurs="0" maxOccurs="1"/>
         </xsd:choice>
@@ -30,6 +31,12 @@
             <xsd:element name="type" type="doctrine_type" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
         <xsd:attribute name="enum_sql_declaration" default="false" />
+    </xsd:complexType>
+
+    <xsd:complexType name="doctrine_mongodb">
+        <xsd:sequence>
+            <xsd:element name="type" type="doctrine_mongodb_type" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
     </xsd:complexType>
 
     <xsd:complexType name="js">
@@ -53,6 +60,12 @@
         <xsd:attribute name="name" type="xsd:string" use="required"/>
     </xsd:complexType>
 
+    <xsd:complexType name="doctrine_mongodb_type">
+        <xsd:attribute name="class" type="xsd:string" use="required"/>
+        <xsd:attribute name="type" type="doctrine_mongodb_type_type"/>
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+
     <xsd:simpleType name="doctrine_type_type">
         <xsd:restriction base="xsd:string">
             <xsd:enumeration value="enum"/>
@@ -60,6 +73,13 @@
             <xsd:enumeration value="int"/>
             <xsd:enumeration value="json_collection"/>
             <xsd:enumeration value="csv_collection"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="doctrine_mongodb_type_type">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="single"/>
+            <xsd:enumeration value="collection"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest/dumped_types.php
+++ b/tests/Fixtures/Bridge/Doctrine/DBAL/Types/TypesDumperTest/dumped_types.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ELAO_ENUM_DT\Foo\Bar {
+namespace ELAO_ENUM_DT_DBAL\Foo\Bar {
 
     if (!\class_exists(BazType::class)) {
         class BazType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractEnumType
@@ -89,7 +89,7 @@ namespace ELAO_ENUM_DT\Foo\Bar {
 
 }
 
-namespace ELAO_ENUM_DT\Foo\Baz {
+namespace ELAO_ENUM_DT_DBAL\Foo\Baz {
 
     if (!\class_exists(FooType::class)) {
         class FooType extends \Elao\Enum\Bridge\Doctrine\DBAL\Types\AbstractIntegerEnumType

--- a/tests/Fixtures/Bridge/Doctrine/ODM/Types/GenderEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/ODM/Types/GenderEnumType.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+
+class GenderEnumType extends AbstractEnumType
+{
+    protected function getEnumClass(): string
+    {
+        return Gender::class;
+    }
+}

--- a/tests/Fixtures/Bridge/Doctrine/ODM/Types/SimpleCollectionEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/ODM/Types/SimpleCollectionEnumType.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractCollectionEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+
+class SimpleCollectionEnumType extends AbstractCollectionEnumType
+{
+    protected function getEnumClass(): string
+    {
+        return SimpleEnum::class;
+    }
+}

--- a/tests/Fixtures/Bridge/Doctrine/ODM/Types/SimpleEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/ODM/Types/SimpleEnumType.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+
+class SimpleEnumType extends AbstractEnumType
+{
+    protected function getEnumClass(): string
+    {
+        return SimpleEnum::class;
+    }
+}

--- a/tests/Fixtures/Bridge/Doctrine/ODM/Types/TypesDumperTest/dumped_types.php
+++ b/tests/Fixtures/Bridge/Doctrine/ODM/Types/TypesDumperTest/dumped_types.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ELAO_ENUM_DT_ODM\Foo\Bar {
+
+    if (!\class_exists(BazType::class)) {
+        class BazType extends \Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType
+        {
+            protected function getEnumClass(): string
+            {
+                return \Foo\Bar\Baz::class;
+            }
+        }
+    }
+
+    if (!\class_exists(FooCollectionType::class)) {
+        class FooCollectionType extends \Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractCollectionEnumType
+        {
+            protected function getEnumClass(): string
+            {
+                return \Foo\Bar\Foo::class;
+            }
+        }
+    }
+
+}
+
+namespace ELAO_ENUM_DT_ODM\Foo\Baz {
+
+    if (!\class_exists(FooType::class)) {
+        class FooType extends \Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType
+        {
+            protected function getEnumClass(): string
+            {
+                return \Foo\Baz\Foo::class;
+            }
+        }
+    }
+
+}

--- a/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/xml/doctrine_mongodb_types.xml
+++ b/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/xml/doctrine_mongodb_types.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:elao-enum="http://elao.com/schema/dic/elao_enum"
+           xsi:schemaLocation="http://elao.com/schema/dic/elao_enum http://elao.com/schema/dic/elao_enum/elao_enum.xsd">
+
+    <elao-enum:config>
+        <elao-enum:doctrine_mongodb>
+            <elao-enum:type class="Elao\Enum\Tests\Fixtures\Enum\Gender" name="gender" />
+            <elao-enum:type class="Elao\Enum\Tests\Fixtures\Enum\AnotherEnum" name="another" type="collection" />
+            <elao-enum:type class="Elao\Enum\Tests\Fixtures\Enum\Permissions" name="permissions" type="single" />
+        </elao-enum:doctrine_mongodb>
+    </elao-enum:config>
+</container>

--- a/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/yaml/doctrine_mongodb_types.yaml
+++ b/tests/Fixtures/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension/yaml/doctrine_mongodb_types.yaml
@@ -1,0 +1,6 @@
+elao_enum:
+    doctrine_mongodb:
+        types:
+            gender: Elao\Enum\Tests\Fixtures\Enum\Gender
+            another: { class: Elao\Enum\Tests\Fixtures\Enum\AnotherEnum, type: collection }
+            permissions: { class: Elao\Enum\Tests\Fixtures\Enum\Permissions, type: single }

--- a/tests/Fixtures/Integration/Symfony/config/config.yml
+++ b/tests/Fixtures/Integration/Symfony/config/config.yml
@@ -32,6 +32,23 @@ doctrine:
                 prefix: 'App\Entity'
                 alias: App
 
+doctrine_mongodb:
+    connections:
+        default:
+            server: '%env(resolve:MONGODB_URL)%'
+    default_database: '%env(resolve:MONGODB_DB)%'
+    document_managers:
+        default:
+            mappings:
+                App:
+                    is_bundle: false
+                    type: annotation
+                    dir: '%kernel.project_dir%/src/Document'
+                    prefix: 'App\Document'
+                    alias: Document
+    types:
+        gender: 'Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types\GenderEnumType'
+
 services:
     logger:
         class: Psr\Log\NullLogger

--- a/tests/Fixtures/Integration/Symfony/src/Document/User.php
+++ b/tests/Fixtures/Integration/Symfony/src/Document/User.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace App\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+
+/**
+ * @ODM\Document()
+ */
+class User
+{
+    /**
+     * @ODM\Id()
+     */
+    private $id;
+
+    /**
+     * @var Gender
+     *
+     * @ODM\Field(type="gender")
+     */
+    private $gender;
+
+    public function __construct(?Gender $gender = null)
+    {
+        $this->gender = $gender;
+    }
+
+    public function getGender(): ?Gender
+    {
+        return $this->gender;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/Integration/Symfony/src/Kernel.php
+++ b/tests/Fixtures/Integration/Symfony/src/Kernel.php
@@ -8,17 +8,20 @@
  * @author Elao <contact@elao.com>
  */
 
+namespace App;
+
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Elao\Enum\Bridge\Symfony\Bundle\ElaoEnumBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 /**
- * AppKernel for tests.
+ * Kernel for tests.
  */
-class AppKernel extends Kernel
+class Kernel extends BaseKernel
 {
     public function registerBundles()
     {
@@ -26,6 +29,7 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new TwigBundle(),
             new DoctrineBundle(),
+            new DoctrineMongoDBBundle(),
             new ElaoEnumBundle(),
         ];
     }

--- a/tests/Integration/Bridge/Doctrine/DBAL/Type/EnumTypeTest.php
+++ b/tests/Integration/Bridge/Doctrine/DBAL/Type/EnumTypeTest.php
@@ -11,8 +11,8 @@
 namespace Elao\Enum\Tests\Integration\Bridge\Doctrine\DBAL\Type;
 
 use App\Entity\User;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
 use Elao\Enum\Tests\Fixtures\Enum\Gender;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -26,7 +26,9 @@ class EnumTypeTest extends KernelTestCase
         $kernel = static::bootKernel();
         $container = $kernel->getContainer();
         $this->em = $container->get('doctrine.orm.entity_manager');
-        (new ORMPurger($this->em))->purge();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropDatabase();
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Bridge/Doctrine/ODM/Type/EnumTypeTest.php
+++ b/tests/Integration/Bridge/Doctrine/ODM/Type/EnumTypeTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Integration\Bridge\Doctrine\ODM\Type;
+
+use App\Document\User;
+use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+use MongoDB\BSON\ObjectId;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class EnumTypeTest extends KernelTestCase
+{
+    /** @var DocumentManager */
+    private $dm;
+
+    protected function setUp(): void
+    {
+        $kernel = static::bootKernel();
+        $container = $kernel->getContainer();
+        $this->dm = $container->get('doctrine_mongodb.odm.document_manager');
+        (new MongoDBPurger($this->dm))->purge();
+    }
+
+    public function testEnumType(): void
+    {
+        $user = new User(Gender::MALE());
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $user = $this->dm->find(User::class, $user->getId());
+
+        self::assertSame(Gender::MALE(), $user->getGender());
+    }
+
+    public function testEnumTypeOnNullFromPHP(): void
+    {
+        $user = new User();
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        /** @var User $user */
+        $user = $this->dm->find(User::class, $user->getId());
+
+        self::assertNull($user->getGender());
+    }
+
+    public function testQueryByValueOrEnumInstance(): void
+    {
+        $user = new User(Gender::FEMALE());
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $qb = $this->dm->createQueryBuilder(User::class);
+        $repo = $this->dm->getRepository(User::class);
+
+        self::assertEquals($user, $qb->field('gender')->equals(Gender::FEMALE())->getQuery()->toArray()[0]);
+        self::assertEquals($user, $qb->field('gender')->equals(Gender::FEMALE)->getQuery()->toArray()[0]);
+        self::assertEmpty($qb->field('gender')->equals(Gender::MALE())->getQuery()->toArray());
+
+        self::assertEquals($user, $repo->findOneBy(['gender' => Gender::FEMALE()]));
+        self::assertEquals($user, $repo->findOneBy(['gender' => Gender::FEMALE]));
+        self::assertNull($repo->findOneBy(['gender' => Gender::MALE()]));
+    }
+
+    public function testEnumIsConvertedToValueDuringQuery(): void
+    {
+        $qb = $this->dm->createQueryBuilder(User::class);
+
+        self::assertSame('female', $qb->field('gender')->equals(Gender::FEMALE())->getQuery()->debug('query')['gender']);
+        self::assertSame('male', $qb->field('gender')->equals(Gender::MALE)->getQuery()->debug('query')['gender']);
+        self::assertNull($qb->field('gender')->equals(null)->getQuery()->debug('query')['gender']);
+    }
+
+    public function testEnumTypeOnNullFromDatabase(): void
+    {
+        $insert = $this->dm->getDocumentCollection(User::class)->insertOne(['_id' => new ObjectId(), 'gender' => null]);
+        $user = $this->dm->find(User::class, $insert->getInsertedId());
+
+        self::assertNull($user->getGender());
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/CollectionEnumTypeTest.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/CollectionEnumTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\ODM\Types;
+
+use Doctrine\ODM\MongoDB\Types\Type;
+use Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types\SimpleCollectionEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+use Elao\Enum\Tests\TestCase;
+
+class CollectionEnumTypeTest extends TestCase
+{
+    /** @var SimpleCollectionEnumType */
+    protected $type;
+    protected const NAME = 'simple_collection';
+
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType(self::NAME, SimpleCollectionEnumType::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->type = Type::getType(self::NAME);
+    }
+
+    public function testConvertToDatabaseValue(): void
+    {
+        self::assertSame([0, 2], $this->type->convertToDatabaseValue([
+            SimpleEnum::ZERO(),
+            SimpleEnum::SECOND(),
+        ]));
+    }
+
+    public function testConvertToDatabaseValueReturnsUniqueValues(): void
+    {
+        self::assertSame([0, 2], $this->type->convertToDatabaseValue([
+            SimpleEnum::ZERO(),
+            SimpleEnum::SECOND(),
+            SimpleEnum::ZERO(),
+            SimpleEnum::SECOND(),
+        ]));
+    }
+
+    public function testConvertToDatabaseValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToDatabaseValue(null));
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        self::assertSame(
+            [SimpleEnum::ZERO(), SimpleEnum::SECOND()],
+            $this->type->convertToPHPValue([0, 2])
+        );
+    }
+
+    public function testConvertToPHPValueReturnsUniqueValue(): void
+    {
+        self::assertSame(
+            [SimpleEnum::ZERO(), SimpleEnum::SECOND()],
+            $this->type->convertToPHPValue([0, 2, 0, 2])
+        );
+    }
+
+    public function testConvertToPHPValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToPHPValue(null));
+    }
+
+    public function testConvertToPHPValueOnEmptyArray(): void
+    {
+        self::assertSame([], $this->type->convertToPHPValue([]));
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/EnumTypeTest.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/EnumTypeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\ODM\Types;
+
+use Doctrine\ODM\MongoDB\Types\Type;
+use Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types\GenderEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\Gender;
+use Elao\Enum\Tests\TestCase;
+
+class EnumTypeTest extends TestCase
+{
+    /** @var GenderEnumType */
+    protected $type;
+    protected const NAME = 'gender';
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!Type::hasType(self::NAME)) {
+            Type::addType(self::NAME, GenderEnumType::class);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->type = Type::getType(self::NAME);
+    }
+
+    public function testConvertToDatabaseValue(): void
+    {
+        $databaseValue = $this->type->convertToDatabaseValue(Gender::get(Gender::MALE));
+        self::assertSame('male', $databaseValue);
+    }
+
+    public function testConvertToDatabaseValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToDatabaseValue(null));
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        $PHPValue = $this->type->convertToPHPValue('male');
+        self::assertSame(Gender::get(Gender::MALE), $PHPValue);
+    }
+
+    public function testConvertToPHPValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToPHPValue(null));
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/IntegerEnumTypeTest.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/IntegerEnumTypeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\ODM\Types;
+
+use Doctrine\ODM\MongoDB\Types\Type;
+use Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types\SimpleEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\SimpleEnum;
+use Elao\Enum\Tests\TestCase;
+
+class IntegerEnumTypeTest extends TestCase
+{
+    /** @var SimpleEnumType */
+    protected $type;
+    protected const NAME = 'simple_enum_collection';
+
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType(self::NAME, SimpleEnumType::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->type = Type::getType(self::NAME);
+    }
+
+    public function testConvertToDatabaseValue(): void
+    {
+        $databaseValue = $this->type->convertToDatabaseValue(SimpleEnum::get(SimpleEnum::FIRST));
+        self::assertSame(1, $databaseValue);
+    }
+
+    public function testConvertToDatabaseValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToDatabaseValue(null));
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        $PHPValue = $this->type->convertToPHPValue(1);
+        self::assertSame(SimpleEnum::get(SimpleEnum::FIRST), $PHPValue);
+    }
+
+    public function testConvertToPHPValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToPHPValue(null));
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/TypesDumperTest.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/TypesDumperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\TypesDumper;
+use Elao\Enum\Tests\TestCase;
+
+class TypesDumperTest extends TestCase
+{
+    public const FIXTURES_DIR = FIXTURES_DIR . '/Bridge/Doctrine/ODM/Types/TypesDumperTest';
+
+    /** @var TypesDumper */
+    private $dumper;
+
+    /** @var string */
+    private $dumpPath;
+
+    protected function setUp(): void
+    {
+        $this->dumper = new TypesDumper();
+        $this->dumpPath = sys_get_temp_dir() . '/elao_enum_types_dumper.php';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dumpPath);
+    }
+
+    public function testDumpToFile(): void
+    {
+        $this->dumper->dumpToFile($this->dumpPath, [
+            ['Foo\Bar\Baz', 'single', 'baz'],
+            ['Foo\Bar\Foo', 'collection', 'foo_collection'],
+            ['Foo\Baz\Foo', 'single', 'foo'],
+        ]);
+
+        self::assertFileEquals(self::FIXTURES_DIR . '/dumped_types.php', $this->dumpPath);
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPassTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPassTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineODMTypesPass;
+use Elao\Enum\Tests\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DoctrineODMTypesPassTest extends TestCase
+{
+    /** @var DoctrineODMTypesPass */
+    private $pass;
+
+    /** @var string */
+    private $dumpPath;
+
+    protected function setUp(): void
+    {
+        $this->dumpPath = sys_get_temp_dir() . '/elao_enum_types_dumper.php';
+        $this->pass = new DoctrineODMTypesPass($this->dumpPath);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dumpPath);
+    }
+
+    public function testDoesNothingOnNoTypesSet(): void
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('doctrine_mongodb.odm.manager_configurator.abstract', \stdClass::class);
+
+        $this->pass->process($container);
+
+        self::assertNull($def->getFile());
+        self::assertFileDoesNotExist($this->dumpPath);
+    }
+
+    public function testDumpsOnTypesSet(): void
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('doctrine_mongodb.odm.manager_configurator.abstract', \stdClass::class);
+        $container->getParameterBag()->set('.elao_enum.doctrine_mongodb_types', [
+            ['Foo\Bar\Baz', 'single', 'baz'],
+            ['Foo\Bar\Qux', 'collection', 'qux'],
+        ]);
+
+        $this->pass->process($container);
+
+        self::assertSame($this->dumpPath, $def->getFile());
+        self::assertFileExists($this->dumpPath);
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -185,6 +185,9 @@ class ConfigurationTest extends TestCase
                 'enum_sql_declaration' => false,
                 'types' => [],
             ],
+            'doctrine_mongodb' => [
+                'types' => [],
+            ],
             'js' => [
                 'base_dir' => null,
                 'lib_path' => null,

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtensionTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtensionTest.php
@@ -11,6 +11,7 @@
 namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Bundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\ElaoEnumExtension;
 use Elao\Enum\Bridge\Symfony\Console\Command\DumpJsEnumsCommand;
 use Elao\Enum\Bridge\Symfony\HttpKernel\Controller\ArgumentResolver\EnumValueResolver;
@@ -98,16 +99,34 @@ abstract class ElaoEnumExtensionTest extends TestCase
             [
                 'dbal' => [
                     'types' => [
-                        'gender' => 'ELAO_ENUM_DT\\Elao\\Enum\\Tests\\Fixtures\\Enum\\GenderType',
-                        'another' => 'ELAO_ENUM_DT\\Elao\\Enum\\Tests\\Fixtures\\Enum\\AnotherEnumType',
-                        'permissions' => 'ELAO_ENUM_DT\\Elao\\Enum\\Tests\\Fixtures\\Enum\\PermissionsType',
-                        'simple_collection_json' => 'ELAO_ENUM_DT\\Elao\\Enum\\Tests\\Fixtures\\Enum\\SimpleEnumJsonCollectionType',
-                        'simple_collection_csv' => 'ELAO_ENUM_DT\\Elao\\Enum\\Tests\\Fixtures\\Enum\\SimpleEnumCsvCollectionType',
+                        'gender' => 'ELAO_ENUM_DT_DBAL\\Elao\\Enum\\Tests\\Fixtures\\Enum\\GenderType',
+                        'another' => 'ELAO_ENUM_DT_DBAL\\Elao\\Enum\\Tests\\Fixtures\\Enum\\AnotherEnumType',
+                        'permissions' => 'ELAO_ENUM_DT_DBAL\\Elao\\Enum\\Tests\\Fixtures\\Enum\\PermissionsType',
+                        'simple_collection_json' => 'ELAO_ENUM_DT_DBAL\\Elao\\Enum\\Tests\\Fixtures\\Enum\\SimpleEnumJsonCollectionType',
+                        'simple_collection_csv' => 'ELAO_ENUM_DT_DBAL\\Elao\\Enum\\Tests\\Fixtures\\Enum\\SimpleEnumCsvCollectionType',
                     ],
                     'mapping_types' => ['enum' => 'string'],
                 ],
             ],
         ], $container->getExtensionConfig('doctrine'));
+    }
+
+    public function testDoctrineOdmTypesArePrepended(): void
+    {
+        $container = $this->createContainerFromFile('doctrine_mongodb_types', false);
+        /** @var ElaoEnumExtension $ext */
+        $ext = $container->getExtension('elao_enum');
+        $ext->prepend($container);
+
+        self::assertEquals([
+            [
+                'types' => [
+                    'gender' => 'ELAO_ENUM_DT_ODM\\Elao\\Enum\\Tests\\Fixtures\\Enum\\GenderType',
+                    'another' => 'ELAO_ENUM_DT_ODM\\Elao\\Enum\\Tests\\Fixtures\\Enum\\AnotherEnumCollectionType',
+                    'permissions' => 'ELAO_ENUM_DT_ODM\\Elao\\Enum\\Tests\\Fixtures\\Enum\\PermissionsType',
+                ],
+            ],
+        ], $container->getExtensionConfig('doctrine_mongodb'));
     }
 
     public function testTranslationExtractor(): void
@@ -167,7 +186,10 @@ abstract class ElaoEnumExtensionTest extends TestCase
     protected function createContainer(): ContainerBuilder
     {
         return new ContainerBuilder(new EnvPlaceholderParameterBag([
-            'kernel.bundles' => ['DoctrineBundle' => DoctrineBundle::class],
+            'kernel.bundles' => [
+                'DoctrineBundle' => DoctrineBundle::class,
+                'DoctrineMongoDBBundle' => DoctrineMongoDBBundle::class,
+            ],
             'kernel.cache_dir' => self::FIXTURES_PATH . '/cache_dir',
         ]));
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,13 +8,6 @@
  * @author Elao <contact@elao.com>
  */
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\ORM\Tools\SchemaTool;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Filesystem\Filesystem;
-
 date_default_timezone_set('UTC');
 
 $loader = require __DIR__ . '/../vendor/autoload.php';
@@ -27,33 +20,5 @@ if (file_exists($varDumper = __DIR__ . '/../vendor/symfony/symfony/src/Symfony/C
 
 const PACKAGE_ROOT_DIR = __DIR__ . '/..';
 const FIXTURES_DIR = __DIR__ . '/Fixtures';
-
-// Prepare integration tests:
-require __DIR__ . '/Fixtures/Integration/Symfony/src/AppKernel.php';
-
-// Empty generated symfony cache
-(new Filesystem())->remove(__DIR__ . '/Fixtures/Integration/var/cache');
-
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
-
-$kernel = new AppKernel('test', true);
-$kernel->boot();
-$doctrine = $kernel->getContainer()->get('doctrine');
-$connectionName = $doctrine->getDefaultConnectionName();
-$managerName = $doctrine->getDefaultManagerName();
-$manager = $doctrine->getManager($managerName);
-$schemaTool = new SchemaTool($manager);
-
-$schemaTool->dropDatabase();
-
-$application = new Application($kernel);
-$application->setAutoExit(false);
-
-// Create database
-$input = new ArrayInput(['command' => 'doctrine:database:create']);
-$application->run($input, new NullOutput());
-// Create database schema
-$input = new ArrayInput(['command' => 'doctrine:schema:create']);
-$application->run($input, new NullOutput());
 
 return $loader;


### PR DESCRIPTION
Fixes #143 

This change introduces Doctrine ODM bridge.

- [x] Introduce basic enum support
- [x] Support for collection of enums 
- [x] Tests
- [x] Support for null values from php and database 
- [x] Readme changes
- [x] Types Dumper
- [x] Bundle integration

From what I see, it is not possible to handle `null` values in ODM in a custom way - they will alway be persisted and fetched as `null`: https://github.com/doctrine/mongodb-odm/blob/85d2b9f9664517ca0ece48547be3e68f7a2a2e8f/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php#L71-L77