### PR TITLE
add Stringable interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.3"
+        "php": ">=7.3",
+        "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",

--- a/src/ReadableEnumInterface.php
+++ b/src/ReadableEnumInterface.php
@@ -11,12 +11,13 @@
 namespace Elao\Enum;
 
 use Elao\Enum\Exception\InvalidValueException;
+use Stringable;
 
 /**
  * @template T of int|string
  * @implements EnumInterface<T>
  */
-interface ReadableEnumInterface extends EnumInterface
+interface ReadableEnumInterface extends EnumInterface, Stringable
 {
     /**
      * Gets an array of the human representations indexed by possible values.


### PR DESCRIPTION
This change makes `ReadableEnumInterface` implement `Stringable` to allow type checks in application code. Symfony Polyfill is used to provide this interface for PHP 7.x.