### PR TITLE
fix collection enum types for ODM

### DIFF
--- a/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
+++ b/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
@@ -10,6 +10,7 @@
 
 namespace Elao\Enum\Bridge\Doctrine\ODM\Types;
 
+use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\CollectionType;
 use Elao\Enum\EnumInterface;
 
@@ -18,6 +19,8 @@ use Elao\Enum\EnumInterface;
  */
 abstract class AbstractCollectionEnumType extends CollectionType
 {
+    use ClosureToPHP;
+
     public function convertToDatabaseValue($value)
     {
         if (\is_array($value)) {


### PR DESCRIPTION
I didn't test properly the type for enum collections in ODM previously and just found an issue where the collection is not converted to enums during hydration due to missing `ClosureToPHP` trait. It tells the ODM how to generate the hydrator and default behaviour omits the `convertToPHPValue` call.

The singular enum type was working as it already uses that trait.