### PR TITLE
Fix 5.4 deprecs & types

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -24,20 +24,21 @@ return (new PhpCsFixer\Config())
     ->setFinder($finder)
     ->setRules([
         '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'concat_space' => ['spacing' => 'one'],
+        'header_comment' => ['header' => $header],
+        'native_function_invocation' => ['include' => ['@compiler_optimized']],
+        'no_unneeded_final_method' => false, // final private __construct is a valid use-case
+        'ordered_imports' => true,
         'php_unit_namespaced' => true,
         'php_unit_method_casing' => false,
-        'psr_autoloading' => true,
-        'concat_space' => ['spacing' => 'one'],
-        'phpdoc_summary' => false,
         'phpdoc_annotation_without_dot' => false,
+        'phpdoc_summary' => false,
         'phpdoc_order' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => true,
-        'simplified_null_return' => false,
-        'header_comment' => ['header' => $header],
-        'yoda_style' => [],
-        'no_unneeded_final_method' => false, // final private __construct is a valid use-case
-        'native_function_invocation' => ['include' => ['@compiler_optimized']],
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'psr_autoloading' => true,
         'single_line_throw' => false,
+        'simplified_null_return' => false,
+        'yoda_style' => [],
     ])
 ;

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ install: setup
 install:
 	rm -f composer.lock
 	composer config minimum-stability --unset
-	composer remove --no-interaction --dev "doctrine/mongodb-odm" "doctrine/mongodb-odm-bundle"
 	composer update --prefer-dist
 
 install-lowest: setup
@@ -24,10 +23,13 @@ install-highest:
 	composer config minimum-stability dev
 	composer update
 
-install-odm:
-	rm -f composer.lock
-	composer require --no-interaction --dev "doctrine/mongodb-odm:^2.2" "doctrine/mongodb-odm-bundle:^4.3"
-	composer update --prefer-dist
+add-odm:
+	composer require --no-update --no-interaction --dev "doctrine/mongodb-odm:^2.2" "doctrine/mongodb-odm-bundle:^4.3"
+	@echo "Run again appropriate install target to update dependencies"
+
+remove-odm:
+	composer remove --no-update --no-interaction --dev "doctrine/mongodb-odm" "doctrine/mongodb-odm-bundle"
+	@echo "Run again appropriate install target to update dependencies"
 
 ########
 # Test #

--- a/src/Bridge/Doctrine/DBAL/Types/AbstractCsvCollectionEnumType.php
+++ b/src/Bridge/Doctrine/DBAL/Types/AbstractCsvCollectionEnumType.php
@@ -16,6 +16,9 @@ use Elao\Enum\EnumInterface;
 
 abstract class AbstractCsvCollectionEnumType extends SimpleArrayType
 {
+    /**
+     * @return mixed
+     */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
         if (\is_array($value)) {
@@ -27,6 +30,9 @@ abstract class AbstractCsvCollectionEnumType extends SimpleArrayType
         return parent::convertToDatabaseValue($value, $platform);
     }
 
+    /**
+     * @return mixed
+     */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if ($value === null) {

--- a/src/Bridge/Doctrine/DBAL/Types/AbstractEnumSQLDeclarationType.php
+++ b/src/Bridge/Doctrine/DBAL/Types/AbstractEnumSQLDeclarationType.php
@@ -20,7 +20,7 @@ abstract class AbstractEnumSQLDeclarationType extends AbstractEnumType
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         $values = implode(', ', array_map(static function (string $value): string {
             return "'$value'";

--- a/src/Bridge/Doctrine/DBAL/Types/AbstractEnumType.php
+++ b/src/Bridge/Doctrine/DBAL/Types/AbstractEnumType.php
@@ -52,6 +52,8 @@ abstract class AbstractEnumType extends Type
      *
      * @param EnumInterface|null $value
      * @psalm-param T|null $value
+     *
+     * @return mixed
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -64,6 +66,8 @@ abstract class AbstractEnumType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -79,7 +83,7 @@ abstract class AbstractEnumType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
     }
@@ -95,7 +99,7 @@ abstract class AbstractEnumType extends Type
     /**
      * {@inheritdoc}
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Bridge/Doctrine/DBAL/Types/AbstractIntegerEnumType.php
+++ b/src/Bridge/Doctrine/DBAL/Types/AbstractIntegerEnumType.php
@@ -17,7 +17,7 @@ abstract class AbstractIntegerEnumType extends AbstractEnumType
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return $platform->getIntegerTypeDeclarationSQL($fieldDeclaration);
     }
@@ -25,7 +25,7 @@ abstract class AbstractIntegerEnumType extends AbstractEnumType
     /**
      * {@inheritdoc}
      */
-    public function getBindingType()
+    public function getBindingType(): int
     {
         return \PDO::PARAM_INT;
     }

--- a/src/Bridge/Doctrine/DBAL/Types/AbstractJsonCollectionEnumType.php
+++ b/src/Bridge/Doctrine/DBAL/Types/AbstractJsonCollectionEnumType.php
@@ -16,6 +16,9 @@ use Elao\Enum\EnumInterface;
 
 abstract class AbstractJsonCollectionEnumType extends JsonType
 {
+    /**
+     * @return mixed
+     */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
         if (\is_array($value)) {
@@ -27,6 +30,9 @@ abstract class AbstractJsonCollectionEnumType extends JsonType
         return parent::convertToDatabaseValue($value, $platform);
     }
 
+    /**
+     * @return mixed
+     */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         $values = parent::convertToPHPValue($value, $platform);
@@ -41,7 +47,7 @@ abstract class AbstractJsonCollectionEnumType extends JsonType
     /**
      * {@inheritdoc}
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
+++ b/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
@@ -21,6 +21,9 @@ abstract class AbstractCollectionEnumType extends CollectionType
 {
     use ClosureToPHP;
 
+    /**
+     * @return mixed
+     */
     public function convertToDatabaseValue($value)
     {
         if (\is_array($value)) {
@@ -36,6 +39,8 @@ abstract class AbstractCollectionEnumType extends CollectionType
      * {@inheritdoc}
      *
      * @psalm-return array<TEnum>|null
+     *
+     * @return mixed
      */
     public function convertToPHPValue($value)
     {

--- a/src/Bridge/Doctrine/ODM/Types/AbstractEnumType.php
+++ b/src/Bridge/Doctrine/ODM/Types/AbstractEnumType.php
@@ -23,6 +23,8 @@ abstract class AbstractEnumType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToDatabaseValue($value)
     {

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('elao_enum');
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('elao_enum');

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtension.php
@@ -103,12 +103,12 @@ class ElaoEnumExtension extends Extension implements PrependExtensionInterface
         ;
     }
 
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://elao.com/schema/dic/elao_enum';
     }
 
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): string
     {
         return __DIR__ . '/../Resources/config/schema';
     }

--- a/src/Bridge/Symfony/Console/Command/DumpJsEnumsCommand.php
+++ b/src/Bridge/Symfony/Console/Command/DumpJsEnumsCommand.php
@@ -53,7 +53,7 @@ class DumpJsEnumsCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Bridge/Symfony/Form/Type/EnumType.php
+++ b/src/Bridge/Symfony/Form/Type/EnumType.php
@@ -20,6 +20,9 @@ use Symfony\Component\Form\ReversedTransformer;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final
+ */
 class EnumType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -102,7 +105,7 @@ class EnumType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
     }

--- a/src/Bridge/Symfony/Form/Type/FlaggedEnumType.php
+++ b/src/Bridge/Symfony/Form/Type/FlaggedEnumType.php
@@ -18,6 +18,9 @@ use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @final
+ */
 class FlaggedEnumType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -53,7 +56,7 @@ class FlaggedEnumType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return EnumType::class;
     }

--- a/src/Bridge/Symfony/HttpKernel/Controller/ArgumentResolver/EnumValueResolver.php
+++ b/src/Bridge/Symfony/HttpKernel/Controller/ArgumentResolver/EnumValueResolver.php
@@ -16,12 +16,15 @@ use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
+/**
+ * @final
+ */
 class EnumValueResolver implements ArgumentValueResolverInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument)
+    public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         return is_subclass_of($argument->getType(), EnumInterface::class);
     }
@@ -29,7 +32,7 @@ class EnumValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument)
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         /** @var EnumInterface $enumClass */
         $enumClass = $argument->getType();

--- a/src/Bridge/Symfony/Serializer/Normalizer/EnumNormalizer.php
+++ b/src/Bridge/Symfony/Serializer/Normalizer/EnumNormalizer.php
@@ -16,6 +16,9 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
+/**
+ * @final
+ */
 class EnumNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     /**
@@ -23,7 +26,7 @@ class EnumNormalizer implements NormalizerInterface, DenormalizerInterface
      *
      * @param EnumInterface $object
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): string
     {
         return $object->getValue();
     }
@@ -31,7 +34,7 @@ class EnumNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof EnumInterface;
     }
@@ -39,7 +42,7 @@ class EnumNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): EnumInterface
     {
         try {
             return \call_user_func([$class, 'get'], $data);
@@ -51,7 +54,7 @@ class EnumNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return is_a($type, EnumInterface::class, true);
     }

--- a/src/Bridge/Symfony/Validator/Constraint/Enum.php
+++ b/src/Bridge/Symfony/Validator/Constraint/Enum.php
@@ -107,6 +107,8 @@ class Enum extends Choice
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function validatedBy()
     {
@@ -116,13 +118,15 @@ class Enum extends Choice
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOption()
+    public function getDefaultOption(): ?string
     {
         return 'class';
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return string[]
      */
     public function getRequiredOptions()
     {

--- a/src/Bridge/Twig/Extension/EnumExtension.php
+++ b/src/Bridge/Twig/Extension/EnumExtension.php
@@ -18,7 +18,10 @@ use Twig\TwigFunction;
 
 class EnumExtension extends AbstractExtension
 {
-    public function getFunctions()
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('enum_get', [$this, 'get']),

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -159,6 +159,7 @@ abstract class Enum implements EnumInterface, JsonSerializable
     /**
      * @return T
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getValue();

--- a/tests/Fixtures/Bridge/Doctrine/DBAL/Types/GenderEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/DBAL/Types/GenderEnumType.php
@@ -32,7 +32,7 @@ class GenderEnumType extends AbstractEnumType
         return Gender::UNKNOW;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Fixtures/Bridge/Doctrine/DBAL/Types/SimpleCsvCollectionEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/DBAL/Types/SimpleCsvCollectionEnumType.php
@@ -22,7 +22,7 @@ class SimpleCsvCollectionEnumType extends AbstractCsvCollectionEnumType
         return SimpleEnum::class;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Fixtures/Bridge/Doctrine/DBAL/Types/SimpleEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/DBAL/Types/SimpleEnumType.php
@@ -32,7 +32,7 @@ class SimpleEnumType extends AbstractIntegerEnumType
         return SimpleEnum::ZERO;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Fixtures/Bridge/Doctrine/DBAL/Types/SimpleJsonCollectionEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/DBAL/Types/SimpleJsonCollectionEnumType.php
@@ -22,7 +22,7 @@ class SimpleJsonCollectionEnumType extends AbstractJsonCollectionEnumType
         return SimpleEnum::class;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Fixtures/Integration/Symfony/src/Kernel.php
+++ b/tests/Fixtures/Integration/Symfony/src/Kernel.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Kernel as BaseKernel;
  */
 class Kernel extends BaseKernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return array_filter([
             new FrameworkBundle(),
@@ -49,7 +49,7 @@ class Kernel extends BaseKernel
         }
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__ . '/../';
     }


### PR DESCRIPTION
I think we should be safe for allowing Symfony 6 without major BC breaks, so we may just release a minor version.
The main impact is on DBAL types for which some types are added on methods, but these are not likely to be overwritten in the context, nor it'll be a big BC on userland.

If it comes to be an issue, we could still conditionally declare the classes according to the detected return types in base ones.

---

refs:
- https://wouterj.nl/2021/09/symfony-6-native-typing
- https://symfony.com/doc/5.4/setup/upgrade_major.html#upgrading-to-symfony-6-add-native-return-types