### PR TITLE
Fix typo (extra backtick character) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ It'll actually generate & register the types classes for you, saving you from wr
 
 A default value in case of `null` from the database or from PHP can be configured with the `default` option:
 
-````yaml
+```yaml
 elao_enum:
     doctrine:
         types:


### PR DESCRIPTION
Because of extra backtick in line 543, whole readme document after this line was broken.