### PR TITLE
[CI] Prepare for next SF & PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,50 +57,58 @@ jobs:
             mongodb: true
 
           # Previous Symfony versions
-          - name: 'Test 5.2 Symfony [Linux, PHP 8.0]'
+          - name: 'Test Symfony 5.3 [Linux, PHP 8.0]'
             os: 'ubuntu-latest'
-            symfony: '5.2.*'
             php: '8.0'
+            symfony: '5.3.*'
 
           # Previous PHP versions
-          - name: 'Test latest Symfony [Linux, PHP 7.3]'
+          - name: 'Test Symfony 5.4 [Linux, PHP 7.3]'
             os: 'ubuntu-latest'
             php: '7.3'
+            symfony: '5.4.*@dev'
+            allow-unstable: true
 
-          - name: 'Test latest Symfony [Linux, PHP 7.4]'
+          - name: 'Test Symfony 5.4 [Linux, PHP 7.4] (with code coverage)'
             os: 'ubuntu-latest'
             php: '7.4'
             mongodb: true
-
-          # Most recent versions
-          - name: 'Test latest Symfony [Linux, PHP 8.0] (with code coverage)'
-            os: 'ubuntu-latest'
-            php: '8.0'
+            symfony: '5.4.*@dev'
+            allow-unstable: true
             code-coverage: true
 
-          - name: 'Test latest Symfony [Windows, PHP 8.0]'
-            os: 'windows-latest'
-            php: '8.0'
-            mongodb: true
-
-          # bleeding edge (unreleased dev versions where failures are allowed)
-          - name: 'Test next Symfony [Linux, PHP 8.1] (allowed failure)'
+          # Most recent versions
+          - name: 'Test Symfony 5.4 [Linux, PHP 8.1]'
             os: 'ubuntu-latest'
             php: '8.1'
             symfony: '5.4.*@dev'
-            composer-flags: '--ignore-platform-req php'
             # For now: Could not install mongodb on PHP 8.1.0-dev
             #mongodb: true
             allow-unstable: true
-            allow-failure: true
 
-          - name: 'Test Symfony 6.0 [Linux, PHP 8.1] (allowed failure)'
+          - name: 'Test Symfony 5.4 [Windows, PHP 8.0]'
+            os: 'windows-latest'
+            php: '8.0'
+            symfony: '5.4.*@dev'
+            mongodb: true
+            allow-unstable: true
+
+          - name: 'Test Symfony 6.0 [Linux, PHP 8.1]'
             os: 'ubuntu-latest'
             php: '8.1'
             symfony: '6.0.*@dev'
-            composer-flags: '--ignore-platform-req php'
             allow-unstable: true
-            allow-failure: true
+
+          # Bleeding edge (unreleased dev versions where failures are allowed)
+#          - name: 'Test next Symfony [Linux, PHP 8.1] (allowed failure)'
+#            os: 'ubuntu-latest'
+#            php: '8.1'
+#            symfony: '6.1.*@dev'
+#            composer-flags: '--ignore-platform-req php'
+#            # For now: Could not install mongodb on PHP 8.1.0-dev
+#            #mongodb: true
+#            allow-unstable: true
+#            allow-failure: true
 
     steps:
       - name: 'Set git to use LF'
@@ -116,7 +124,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
-          extensions: pdo_sqlite, mongodb
+          extensions: pdo_sqlite ${{ matrix.mongodb && ', mongodb' }}
           tools: 'composer:v2,flex'
 
       - name: 'Start MongoDB (Linux)'
@@ -141,9 +149,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: 'Allow unstable packages'
-        run: |
-          composer config prefer-stable false
-          composer config minimum-stability dev
+        run: composer config minimum-stability dev
         if: ${{ matrix.allow-unstable }}
 
       - name: 'Remove packages not allowing Symfony 6 yet'

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ install-lowest:
 	composer config minimum-stability --unset
 	composer update --prefer-lowest
 
-install-highest: setup
-install-highest: export SYMFONY_REQUIRE = 5.4.*@dev
-install-highest:
+install-5.4: setup
+install-5.4: export SYMFONY_REQUIRE = 5.4.*@dev
+install-5.4:
 	composer config minimum-stability dev
 	composer update
 
@@ -27,6 +27,13 @@ install-60: setup
 install-60: export SYMFONY_REQUIRE = 6.0.*@dev
 install-60: remove-60unready-deps
 install-60:
+	composer config minimum-stability dev
+	composer update
+
+install-61: setup
+install-61: export SYMFONY_REQUIRE = 6.1.*@dev
+install-61: remove-60unready-deps
+install-61:
 	composer config minimum-stability dev
 	composer update
 


### PR DESCRIPTION
Symfony 5.4/6.0 & PHP 8.1 should not be allowed to fail in two weeks.

---

I don't know yet why the 8.1 builds are failing with:

> Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The annotation "`@ORM\Entity`" in class App\Entity\User was never imported. Did you maybe forget to add a "use" statement for this annotation?

Everything seems fine locally with PHP 8.1 (`PHP 8.1.0-dev (cli) (built: Nov 15 2021 00:35:22) (NTS)`)