### PR TITLE
Override the block prefix

### DIFF
--- a/src/Bridge/Symfony/Form/Type/EnumType.php
+++ b/src/Bridge/Symfony/Form/Type/EnumType.php
@@ -42,4 +42,12 @@ class EnumType extends AbstractType
     {
         return SymfonyEnumType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'elao_enum';
+    }
 }


### PR DESCRIPTION
When trying to use the latest version of this bundle, i got this error : 

```
Symfony\Component\Form\Exception\LogicException:
Unable to render the form because the block names array contains duplicates: "_white_label_theme_row", "enum_row", "enum_row", "choice_row", "form_row".

  at vendor/symfony/form/FormRenderer.php:223
  at Symfony\Component\Form\FormRenderer->searchAndRenderBlock()
     (/srv/cache/dev/twig/2b/2b010bdcb7e7aa2d4ec838dbb4fe1db0.php:1769)
  at __TwigTemplate_90954ca4a1e6b2f9ddb75f0555e99375->block_form_rows()
     (vendor/twig/twig/src/Template.php:171)
  at Twig\Template->displayBlock()
     (/srv/cache/dev/twig/2b/2b010bdcb7e7aa2d4ec838dbb4fe1db0.php:286)
  at __TwigTemplate_90954ca4a1e6b2f9ddb75f0555e99375->block_form_widget_compound()
     (vendor/twig/twig/src/Template.php:171)
  at Twig\Template->displayBlock()
     (/srv/cache/dev/twig/2b/2b010bdcb7e7aa2d4ec838dbb4fe1db0.php:216)
  at __TwigTemplate_90954ca4a1e6b2f9ddb75f0555e99375->block_form_widget()
     (vendor/twig/twig/src/Template.php:171)
  at Twig\Template->displayBlock()
     (vendor/symfony/twig-bridge/Form/TwigRendererEngine.php:51)
  at Symfony\Bridge\Twig\Form\TwigRendererEngine->renderBlock()
     (vendor/symfony/form/FormRenderer.php:258)
  at Symfony\Component\Form\FormRenderer->searchAndRenderBlock()
     (/srv/cache/dev/twig/2b/2b010bdcb7e7aa2d4ec838dbb4fe1db0.php:1571)
  at __TwigTemplate_90954ca4a1e6b2f9ddb75f0555e99375->block_form()
     (vendor/twig/twig/src/Template.php:171)
  at Twig\Template->displayBlock()
     (vendor/symfony/twig-bridge/Form/TwigRendererEngine.php:51)
  at Symfony\Bridge\Twig\Form\TwigRendererEngine->renderBlock()
     (vendor/symfony/form/FormRenderer.php:115)
  at Symfony\Component\Form\FormRenderer->renderBlock()
     (/srv/cache/dev/twig/12/12bd90f22af73456d4863cdb07059ff9.php:43)
  at __TwigTemplate_b71b4decf538da39e29471bdb9de4c45->doDisplay()
     (vendor/twig/twig/src/Template.php:394)
  at Twig\Template->displayWithErrorHandling()
     (vendor/twig/twig/src/Template.php:367)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:379)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:40)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Environment.php:277)
  at Twig\Environment->render()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:220)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->renderView()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:228)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->render()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:266)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->renderForm()
     (src/Interim/Infra/Controller/Admin/WhiteLabelController.php:54)
  at App\Interim\Infra\Controller\Admin\WhiteLabelController->create()
     (vendor/symfony/http-kernel/HttpKernel.php:152)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
     (vendor/autoload_runtime.php:29)
  at require_once('/srv/app/vendor/autoload_runtime.php')
     (public/index.php:7)                
```