### PR TITLE
Add Doctrine ODM integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
             php: '8.1'
             composer-flags: '--prefer-lowest'
             allow-unstable: true
+            mongodb: true
 
           # Previous Symfony versions
           # …
@@ -58,17 +59,20 @@ jobs:
             php: '8.1'
             symfony: '5.4.*@dev'
             allow-unstable: true
+            mongodb: true
 
           - name: 'Test Symfony 5.4 [Windows, PHP 8.1]'
             os: 'windows-latest'
             php: '8.1'
             symfony: '5.4.*@dev'
+            mongodb: true
             allow-unstable: true
 
           - name: 'Test Symfony 6.0 [Linux, PHP 8.1]'
             os: 'ubuntu-latest'
             php: '8.1'
             symfony: '6.0.*@dev'
+            mongodb: true
             allow-unstable: true
 
           # Bleeding edge (unreleased dev versions where failures are allowed)
@@ -79,6 +83,7 @@ jobs:
             composer-flags: '--ignore-platform-req php'
             allow-unstable: true
             allow-failure: true
+            mongodb: true
 
     steps:
       - name: 'Set git to use LF'
@@ -93,9 +98,19 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: pdo_sqlite
+          extensions: pdo_sqlite ${{ matrix.mongodb && ', mongodb' }}
           coverage: pcov
           tools: 'composer:v2,flex'
+
+      - name: 'Start MongoDB (Linux)'
+        uses: supercharge/mongodb-github-action@1.6.0
+        if: ${{ matrix.mongodb && matrix.os == 'ubuntu-latest' }}
+
+      - name: 'Start MongoDB (Windows)'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install mongodb
+        if: ${{ matrix.mongodb && matrix.os == 'windows-latest' }}
 
       - name: 'Get composer cache directory'
         id: composer-cache
@@ -111,6 +126,10 @@ jobs:
       - name: 'Allow unstable packages'
         run: composer config minimum-stability dev
         if: ${{ matrix.allow-unstable }}
+
+      - name: 'Require Doctrine MongoDB dependencies'
+        run: composer require --no-update ${{ matrix.composer-flags }} --dev --no-interaction --ansi "doctrine/mongodb-odm:^2.3" "doctrine/mongodb-odm-bundle:^4.4.1"
+        if: ${{ matrix.mongodb }}
 
       - name: 'Install dependencies'
         run: composer update --prefer-dist ${{ matrix.composer-flags }} --ansi

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,6 +12,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude('tests/Fixtures/Integration/Symfony/var')
     ->exclude('tests/Unit/Bridge/Doctrine/DBAL/Types/TypesDumperTest')
+    ->exclude('tests/Unit/Bridge/Doctrine/ODM/Types/TypesDumperTest')
     // Enum ignored for now since php-cs-fixer removes the traits & extra blank lines:
     ->notPath([
         'tests/Fixtures/Enum/SuitWithAttributesMissingLabel.php',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,8 @@
   </coverage>
   <php>
     <server name="KERNEL_CLASS" value="App\Kernel"/>
+    <env name="MONGODB_URL" value="mongodb://localhost:27017" />
+    <env name="MONGODB_DB" value="enum-test" />
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;max[self]=0&amp;max[total]=9999&amp;verbose=1"/>
     <env name="SYMFONY_PHPUNIT_REQUIRE" value="phpspec/prophecy-phpunit"/>
     <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>

--- a/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
+++ b/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\Common;
+
+abstract class AbstractTypesDumper
+{
+    public function dumpToFile(string $file, array $types)
+    {
+        file_put_contents($file, $this->dump($types));
+    }
+
+    public static function getTypeClassname(string $class, string $type): string
+    {
+        return sprintf('%s\\%s%s', static::getMarker(), $class, static::getSuffixes()[$type]);
+    }
+
+    private function dump(array $types): string
+    {
+        array_walk($types, static function (&$type) {
+            $type = array_pad($type, 4, null);
+        });
+
+        $namespaces = [];
+        foreach ($types as [$enumClass, $type, $name, $default]) {
+            $fqcn = self::getTypeClassname($enumClass, $type);
+            $classname = basename(str_replace('\\', '/', $fqcn));
+            $ns = substr($fqcn, 0, -\strlen($classname) - 1);
+
+            if (!isset($namespaces[$ns])) {
+                $namespaces[$ns] = '';
+            }
+
+            $namespaces[$ns] .= $this->getTypeCode($classname, $enumClass, $type, $name, $default);
+        }
+
+        $code = "<?php\n";
+        foreach ($namespaces as $namespace => $typeCode) {
+            $code .= <<<PHP
+
+namespace $namespace {
+$typeCode
+}
+
+PHP;
+        }
+
+        return $code;
+    }
+
+    abstract protected function getTypeCode(string $classname, string $enumClass, string $type, string $name, \BackedEnum|int|string|null $defaultOnNull = null): string;
+
+    abstract protected static function getSuffixes(): array;
+
+    abstract protected static function getMarker(): string;
+}

--- a/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
+++ b/src/Bridge/Doctrine/DBAL/Types/TypesDumper.php
@@ -12,60 +12,22 @@ declare(strict_types=1);
 
 namespace Elao\Enum\Bridge\Doctrine\DBAL\Types;
 
+use Elao\Enum\Bridge\Doctrine\Common\AbstractTypesDumper;
+
 /**
  * @internal
  */
-class TypesDumper
+class TypesDumper extends AbstractTypesDumper
 {
-    /**
-     * @return void
-     */
-    public function dumpToFile(string $file, array $types)
-    {
-        file_put_contents($file, $this->dump($types));
-    }
+    public const TYPE_SINGLE = 'single';
+    public const TYPES = [
+        self::TYPE_SINGLE,
+    ];
 
-    public static function getTypeClassname(string $class): string
-    {
-        return sprintf('%s\\%sType', static::getMarker(), $class);
-    }
-
-    private function dump(array $types): string
-    {
-        array_walk($types, static function (&$type) {
-            $type = array_pad($type, 3, null);
-        });
-
-        $namespaces = [];
-        foreach ($types as [$enumClass, $name, $default]) {
-            $fqcn = self::getTypeClassname($enumClass);
-            $classname = basename(str_replace('\\', '/', $fqcn));
-            $ns = substr($fqcn, 0, -\strlen($classname) - 1);
-
-            if (!isset($namespaces[$ns])) {
-                $namespaces[$ns] = '';
-            }
-
-            $namespaces[$ns] .= $this->getTypeCode($classname, $enumClass, $name, $default);
-        }
-
-        $code = "<?php\n";
-        foreach ($namespaces as $namespace => $typeCode) {
-            $code .= <<<PHP
-
-namespace $namespace {
-$typeCode
-}
-
-PHP;
-        }
-
-        return $code;
-    }
-
-    private function getTypeCode(
+    protected function getTypeCode(
         string $classname,
         string $enumClass,
+        string $type,
         string $name,
         \BackedEnum|int|string|null $defaultOnNull = null
     ): string {
@@ -102,7 +64,7 @@ PHP;
         PHP;
     }
 
-    private static function getMarker(): string
+    protected static function getMarker(): string
     {
         return 'ELAO_ENUM_DT_DBAL';
     }
@@ -129,5 +91,12 @@ PHP;
                         }
             PHP;
         }
+    }
+
+    protected static function getSuffixes(): array
+    {
+        return [
+            self::TYPE_SINGLE => 'Type',
+        ];
     }
 }

--- a/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
+++ b/src/Bridge/Doctrine/ODM/Types/AbstractCollectionEnumType.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\ODM\Types;
+
+use BackedEnum;
+use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
+use Doctrine\ODM\MongoDB\Types\CollectionType;
+
+/**
+ * @template TEnum of \BackedEnum
+ */
+abstract class AbstractCollectionEnumType extends CollectionType
+{
+    use ClosureToPHP;
+
+    public function convertToDatabaseValue($value): ?array
+    {
+        if (\is_array($value)) {
+            return array_unique(array_values(array_map(static function ($value) {
+                return $value instanceof BackedEnum ? $value->value : $value;
+            }, $value)));
+        }
+
+        return parent::convertToDatabaseValue($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @phpstan-return array<TEnum>|null
+     */
+    public function convertToPHPValue($value): ?array
+    {
+        $values = parent::convertToPHPValue($value);
+
+        if (\is_array($values)) {
+            $enumClass = $this->getEnumClass();
+            $values = array_map([$enumClass, 'from'], array_unique(array_values($values)));
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return class-string<TEnum>
+     */
+    abstract protected function getEnumClass(): string;
+}

--- a/src/Bridge/Doctrine/ODM/Types/AbstractEnumType.php
+++ b/src/Bridge/Doctrine/ODM/Types/AbstractEnumType.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\ODM\Types;
+
+use BackedEnum;
+use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
+use Doctrine\ODM\MongoDB\Types\Type;
+
+/**
+ * @template TEnum of \BackedEnum
+ */
+abstract class AbstractEnumType extends Type
+{
+    use ClosureToPHP;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value): int|string|null
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if ($value instanceof BackedEnum) {
+            return $value->value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @psalm-return TEnum
+     */
+    public function convertToPHPValue($value): ?BackedEnum
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $class = $this->getEnumClass();
+
+        return $class::from($value);
+    }
+
+    /**
+     * @return class-string<TEnum>
+     */
+    abstract protected function getEnumClass(): string;
+}

--- a/src/Bridge/Doctrine/ODM/Types/TypesDumper.php
+++ b/src/Bridge/Doctrine/ODM/Types/TypesDumper.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\Common\AbstractTypesDumper;
+use Elao\Enum\Exception\LogicException;
+
+/**
+ * @internal
+ */
+class TypesDumper extends AbstractTypesDumper
+{
+    public const TYPE_SINGLE = 'single';
+    public const TYPE_COLLECTION = 'collection';
+    public const TYPES = [
+        self::TYPE_SINGLE,
+        self::TYPE_COLLECTION,
+    ];
+
+    protected function getTypeCode(
+        string $classname,
+        string $enumClass,
+        string $type,
+        string $name,
+        \BackedEnum|int|string|null $defaultOnNull = null
+    ): string {
+        $code = <<<PHP
+                        protected function getEnumClass(): string
+                        {
+                            return \\{$enumClass}::class;
+                        }
+            PHP;
+
+        $baseClass = match ($type) {
+            self::TYPE_SINGLE => AbstractEnumType::class,
+            self::TYPE_COLLECTION => AbstractCollectionEnumType::class,
+            default => throw new LogicException(sprintf('Unexpected type "%s"', $type)),
+        };
+
+        return <<<PHP
+
+            if (!\class_exists($classname::class)) {
+                class $classname extends \\{$baseClass}
+                {
+        $code
+                }
+            }
+
+        PHP;
+    }
+
+    protected static function getSuffixes(): array
+    {
+        return [
+            self::TYPE_SINGLE => 'Type',
+            self::TYPE_COLLECTION => 'CollectionType',
+        ];
+    }
+
+    protected static function getMarker(): string
+    {
+        return 'ELAO_ENUM_DT_ODM';
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPass.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\TypesDumper;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DoctrineODMTypesPass implements CompilerPassInterface
+{
+    /** @var string */
+    private $typesFilePath;
+
+    public function __construct(string $typesFilePath)
+    {
+        $this->typesFilePath = $typesFilePath;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('.elao_enum.doctrine_mongodb_types')) {
+            return;
+        }
+
+        $types = $container->getParameter('.elao_enum.doctrine_mongodb_types');
+
+        (new TypesDumper())->dumpToFile($this->typesFilePath, $types);
+
+        if (!empty($types)) {
+            $configuratorDefinition = $container->getDefinition('doctrine_mongodb.odm.manager_configurator.abstract');
+            $configuratorDefinition->setFile($this->typesFilePath);
+        }
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection;
 
+use Elao\Enum\Bridge\Doctrine\DBAL\Types\TypesDumper as DBALTypesDumper;
+use Elao\Enum\Bridge\Doctrine\ODM\Types\TypesDumper as ODMTypesDumper;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -23,6 +25,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('elao_enum');
 
         $this->addDoctrineDbalSection($treeBuilder->getRootNode());
+        $this->addDoctrineOdmSection($treeBuilder->getRootNode());
 
         return $treeBuilder;
     }
@@ -66,10 +69,65 @@ class Configuration implements ConfigurationInterface
                                 ->thenInvalid(sprintf('Invalid class. Expected instance of "%s"', \BackedEnum::class) . '. Got %s.')
                             ->end()
                         ->end()
+                        ->enumNode('type')
+                            ->values(DBALTypesDumper::TYPES)
+                            ->cannotBeEmpty()
+                            ->defaultValue(DBALTypesDumper::TYPE_SINGLE)
+                        ->end()
                         ->variableNode('default')
                             ->info('Default enumeration case on NULL')
                             ->cannotBeEmpty()
                             ->defaultValue(null)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+    }
+
+    private function addDoctrineOdmSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode->children()
+            ->arrayNode('doctrine_mongodb')
+            ->addDefaultsIfNotSet()
+            ->fixXmlConfig('type')
+            ->children()
+                ->arrayNode('types')
+                    ->beforeNormalization()
+                        ->always(static function (array $values): array {
+                            // Allows reusing type name as the enum class implicitly
+                            foreach ($values as $name => &$config) {
+                                if (null === $config) {
+                                    $config['class'] = $name;
+                                    continue;
+                                }
+
+                                if (\is_array($config) && !isset($config['class'])) {
+                                    $config['class'] = $name;
+                                }
+                            }
+
+                            return $values;
+                        })
+                    ->end()
+                    ->useAttributeAsKey('name')
+                    ->arrayPrototype()
+                    ->beforeNormalization()
+                        // Allows passing the class as string directly instead of the whole config array
+                        ->ifString()->then(static function (string $v): array { return ['class' => $v]; })
+                    ->end()
+                    ->children()
+                        ->scalarNode('class')
+                            ->cannotBeEmpty()
+                            ->validate()
+                                ->ifTrue(static function (string $class): bool { return !is_a($class, \BackedEnum::class, true); })
+                                ->thenInvalid(sprintf('Invalid class. Expected instance of "%s"', \BackedEnum::class) . '. Got %s.')
+                            ->end()
+                        ->end()
+                        ->enumNode('type')
+                            ->values(ODMTypesDumper::TYPES)
+                            ->cannotBeEmpty()
+                            ->defaultValue(ODMTypesDumper::TYPE_SINGLE)
                         ->end()
                     ->end()
                 ->end()

--- a/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
+++ b/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elao\Enum\Bridge\Symfony\Bundle;
 
 use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineDBALTypesPass;
+use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineODMTypesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -24,6 +25,10 @@ class ElaoEnumBundle extends Bundle
 
         $container->addCompilerPass(
             new DoctrineDBALTypesPass($container->getParameter('kernel.cache_dir') . '/elao_enum_doctrine_dbal_types.php')
+        );
+
+        $container->addCompilerPass(
+            new DoctrineODMTypesPass($container->getParameter('kernel.cache_dir') . '/elao_enum_doctrine_odm_types.php')
         );
     }
 

--- a/tests/Fixtures/Bridge/Doctrine/ODM/Types/RequestStatusCollectionType.php
+++ b/tests/Fixtures/Bridge/Doctrine/ODM/Types/RequestStatusCollectionType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractCollectionEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\RequestStatus;
+
+class RequestStatusCollectionType extends AbstractCollectionEnumType
+{
+    protected function getEnumClass(): string
+    {
+        return RequestStatus::class;
+    }
+}

--- a/tests/Fixtures/Bridge/Doctrine/ODM/Types/RequestStatusType.php
+++ b/tests/Fixtures/Bridge/Doctrine/ODM/Types/RequestStatusType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\RequestStatus;
+
+class RequestStatusType extends AbstractEnumType
+{
+    protected function getEnumClass(): string
+    {
+        return RequestStatus::class;
+    }
+}

--- a/tests/Fixtures/Bridge/Doctrine/ODM/Types/SuitEnumType.php
+++ b/tests/Fixtures/Bridge/Doctrine/ODM/Types/SuitEnumType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types;
+
+use Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\Suit;
+
+class SuitEnumType extends AbstractEnumType
+{
+    protected function getEnumClass(): string
+    {
+        return Suit::class;
+    }
+}

--- a/tests/Fixtures/Integration/Symfony/config/mongodb.yml
+++ b/tests/Fixtures/Integration/Symfony/config/mongodb.yml
@@ -1,0 +1,19 @@
+doctrine_mongodb:
+  connections:
+    default:
+      server: '%env(resolve:MONGODB_URL)%'
+  default_database: '%env(resolve:MONGODB_DB)%'
+  document_managers:
+    default:
+      mappings:
+        App:
+          is_bundle: false
+          type: attribute
+          dir: '%kernel.project_dir%/src/Document'
+          prefix: 'App\Document'
+          alias: Document
+
+elao_enum:
+  doctrine_mongodb:
+    types:
+      App\Enum\Suit: 'App\Enum\Suit'

--- a/tests/Fixtures/Integration/Symfony/src/Document/Card.php
+++ b/tests/Fixtures/Integration/Symfony/src/Document/Card.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace App\Document;
+
+use App\Enum\Suit;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document]
+class Card
+{
+    #[ODM\Id]
+    private string $id;
+
+    #[ODM\Field(type: Suit::class, nullable: true)]
+    private ?Suit $suit;
+
+    public function __construct(?Suit $suit = null)
+    {
+        $this->suit = $suit;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getSuit(): ?Suit
+    {
+        return $this->suit;
+    }
+}

--- a/tests/Fixtures/Integration/Symfony/src/Entity/Card.php
+++ b/tests/Fixtures/Integration/Symfony/src/Entity/Card.php
@@ -38,7 +38,7 @@ class Card
         return $this->uuid;
     }
 
-    public function getSuit(): Suit
+    public function getSuit(): ?Suit
     {
         return $this->suit;
     }

--- a/tests/Fixtures/Integration/Symfony/src/Kernel.php
+++ b/tests/Fixtures/Integration/Symfony/src/Kernel.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace App;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Elao\Enum\Bridge\Symfony\Bundle\ElaoEnumBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -28,6 +29,7 @@ class Kernel extends BaseKernel
         return array_filter([
             new FrameworkBundle(),
             new DoctrineBundle(),
+            class_exists(DoctrineMongoDBBundle::class) ? new DoctrineMongoDBBundle() : null,
             new ElaoEnumBundle(),
         ]);
     }
@@ -35,6 +37,10 @@ class Kernel extends BaseKernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load($this->getProjectDir() . '/config/config.yml');
+
+        if (class_exists(DoctrineMongoDBBundle::class)) {
+            $loader->load($this->getProjectDir() . '/config/mongodb.yml');
+        }
     }
 
     public function getProjectDir(): string

--- a/tests/Integration/Bridge/Doctrine/ODM/Type/EnumTypeTest.php
+++ b/tests/Integration/Bridge/Doctrine/ODM/Type/EnumTypeTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Integration\Bridge\Doctrine\ODM\Type;
+
+use App\Document\Card;
+use App\Enum\Suit;
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use MongoDB\BSON\ObjectId;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class EnumTypeTest extends KernelTestCase
+{
+    private DocumentManager $dm;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(DoctrineMongoDBBundle::class)) {
+            self::markTestSkipped('Doctrine MongoDB ODM bundle not installed');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $kernel = static::bootKernel();
+        $container = $kernel->getContainer();
+        $this->dm = $container->get('doctrine_mongodb.odm.document_manager');
+
+        foreach ($this->dm->getMetadataFactory()->getAllMetadata() as $metadata) {
+            if ($metadata->isMappedSuperclass) {
+                continue;
+            }
+
+            $this->dm->getDocumentCollection($metadata->name)->drop();
+        }
+
+        $this->dm->getSchemaManager()->ensureIndexes();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dm->close();
+
+        parent::tearDown();
+    }
+
+    public function testEnumType(): void
+    {
+        $card = new Card(Suit::Hearts);
+        $this->dm->persist($card);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $card = $this->dm->find(Card::class, $card->getId());
+
+        self::assertSame(Suit::Hearts, $card->getSuit());
+    }
+
+    public function testEnumTypeOnNullFromPHP(): void
+    {
+        $card = new Card();
+        $this->dm->persist($card);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $card = $this->dm->find(Card::class, $card->getId());
+
+        self::assertNull($card->getSuit());
+    }
+
+    public function testQueryByValueOrEnumInstance(): void
+    {
+        $card = new Card(Suit::Clubs);
+        $this->dm->persist($card);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $qb = $this->dm->createQueryBuilder(Card::class);
+        $repo = $this->dm->getRepository(Card::class);
+
+        self::assertEquals($card, $qb->field('suit')->equals(Suit::Clubs)->getQuery()->toArray()[0]);
+        self::assertEquals($card, $qb->field('suit')->equals('C')->getQuery()->toArray()[0]);
+        self::assertEmpty($qb->field('suit')->equals(Suit::Hearts)->getQuery()->toArray());
+        self::assertEmpty($qb->field('suit')->equals('H')->getQuery()->toArray());
+
+        self::assertEquals($card, $repo->findOneBy(['suit' => Suit::Clubs]));
+        self::assertEquals($card, $repo->findOneBy(['suit' => 'C']));
+        self::assertNull($repo->findOneBy(['suit' => Suit::Hearts]));
+    }
+
+    public function testEnumIsConvertedToValueDuringQuery(): void
+    {
+        $qb = $this->dm->createQueryBuilder(Card::class);
+
+        self::assertSame('C', $qb->field('suit')->equals(Suit::Clubs)->getQuery()->debug('query')['suit']);
+        self::assertSame('H', $qb->field('suit')->equals('H')->getQuery()->debug('query')['suit']);
+        self::assertNull($qb->field('suit')->equals(null)->getQuery()->debug('query')['suit']);
+    }
+
+    public function testEnumTypeOnNullFromDatabase(): void
+    {
+        $insert = $this->dm->getDocumentCollection(Card::class)->insertOne(['_id' => new ObjectId(), 'suit' => null]);
+        $card = $this->dm->find(Card::class, $insert->getInsertedId());
+
+        self::assertNull($card->getSuit());
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/Common/Types/BaseTypesDumperTest.php
+++ b/tests/Unit/Bridge/Doctrine/Common/Types/BaseTypesDumperTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\Common\Types;
+
+use Elao\Enum\Bridge\Doctrine\Common\AbstractTypesDumper;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTypesDumperTest extends TestCase
+{
+    private readonly string $dumpPath;
+
+    protected function setUp(): void
+    {
+        $this->dumpPath = sys_get_temp_dir() . '/elao_enum_types_dumper.php';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dumpPath);
+    }
+
+    public function testDumpToFile(): void
+    {
+        $this->getDumper()->dumpToFile($this->dumpPath, $this->getTypes());
+
+        self::assertSnapshotFileMatchesFile($this->getSnapshotPath(), $this->dumpPath);
+    }
+
+    abstract protected function getSnapshotPath(): string;
+
+    abstract protected function getTypes(): array;
+
+    abstract protected function getDumper(): AbstractTypesDumper;
+
+    private static function assertSnapshotFileMatchesFile(string $snapshotPath, string $actualPath)
+    {
+        self::updateSnapshot($snapshotPath, file_get_contents($actualPath));
+
+        self::assertFileEquals($snapshotPath, $actualPath);
+    }
+
+    private static function updateSnapshot(string $snapshotPath, string $content): void
+    {
+        if (true === \defined('UPDATE_EXPECTATIONS') && true === \constant('UPDATE_EXPECTATIONS')) {
+            file_put_contents($snapshotPath, rtrim($content) . "\n");
+        }
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/CollectionEnumTypeTest.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/CollectionEnumTypeTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\ODM\Types;
+
+use Doctrine\ODM\MongoDB\Types\Type;
+use Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types\RequestStatusCollectionType;
+use Elao\Enum\Tests\Fixtures\Enum\RequestStatus;
+use PHPUnit\Framework\TestCase;
+use ValueError;
+
+class CollectionEnumTypeTest extends TestCase
+{
+    /** @var RequestStatusCollectionType */
+    private $type;
+    private const NAME = 'request_statuses';
+
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType(self::NAME, RequestStatusCollectionType::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->type = Type::getType(self::NAME);
+    }
+
+    public function testConvertToDatabaseValue(): void
+    {
+        self::assertSame([403, 500], $this->type->convertToDatabaseValue([
+            RequestStatus::Forbidden,
+            RequestStatus::InternalServerError,
+        ]));
+    }
+
+    public function testConvertToDatabaseValueReturnsUniqueValues(): void
+    {
+        self::assertSame([200, 500], $this->type->convertToDatabaseValue([
+            RequestStatus::Success,
+            RequestStatus::InternalServerError,
+            RequestStatus::Success,
+            RequestStatus::InternalServerError,
+        ]));
+    }
+
+    public function testConvertToDatabaseValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToDatabaseValue(null));
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        self::assertSame(
+            [RequestStatus::Success, RequestStatus::Forbidden],
+            $this->type->convertToPHPValue([200, 403])
+        );
+    }
+
+    public function testConvertToPHPValueReturnsUniqueValue(): void
+    {
+        self::assertSame(
+            [RequestStatus::Success, RequestStatus::Forbidden],
+            $this->type->convertToPHPValue([200, 403, 200, 200])
+        );
+    }
+
+    public function testConvertToPHPValueOnNull(): void
+    {
+        self::assertNull($this->type->convertToPHPValue(null));
+    }
+
+    public function testConvertToPHPValueOnEmptyArray(): void
+    {
+        self::assertSame([], $this->type->convertToPHPValue([]));
+    }
+
+    public function testConvertToPHPValueOnInvalidValue(): void
+    {
+        $this->expectException(ValueError::class);
+        $this->type->convertToPHPValue([301]);
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/EnumTypeTest.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/EnumTypeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\ODM\Types;
+
+use Doctrine\ODM\MongoDB\Types\Type;
+use Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types\RequestStatusType;
+use Elao\Enum\Tests\Fixtures\Bridge\Doctrine\ODM\Types\SuitEnumType;
+use Elao\Enum\Tests\Fixtures\Enum\RequestStatus;
+use Elao\Enum\Tests\Fixtures\Enum\Suit;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+use ValueError;
+
+class EnumTypeTest extends TestCase
+{
+    /** @var SuitEnumType */
+    private $stringType;
+
+    /** @var RequestStatusType */
+    private $intType;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (Type::hasType(Suit::class)) {
+            Type::overrideType(Suit::class, SuitEnumType::class);
+        } else {
+            Type::addType(Suit::class, SuitEnumType::class);
+        }
+
+        if (Type::hasType(RequestStatus::class)) {
+            Type::overrideType(RequestStatus::class, RequestStatusType::class);
+        } else {
+            Type::addType(RequestStatus::class, RequestStatusType::class);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->stringType = Type::getType(Suit::class);
+        $this->intType = Type::getType(RequestStatus::class);
+    }
+
+    public function testConvertToDatabaseValue(): void
+    {
+        self::assertSame('H', $this->stringType->convertToDatabaseValue(Suit::Hearts));
+        self::assertSame(403, $this->intType->convertToDatabaseValue(RequestStatus::Forbidden));
+    }
+
+    public function testConvertToDatabaseValueOnNull(): void
+    {
+        self::assertNull($this->stringType->convertToDatabaseValue(null));
+        self::assertNull($this->intType->convertToDatabaseValue(null));
+    }
+
+    public function testConvertToPHPValue(): void
+    {
+        self::assertSame(Suit::Hearts, $this->stringType->convertToPHPValue('H'));
+        self::assertSame(RequestStatus::Forbidden, $this->intType->convertToPHPValue(403));
+    }
+
+    public function testConvertToPHPValueOnNull(): void
+    {
+        self::assertNull($this->stringType->convertToPHPValue(null));
+        self::assertNull($this->intType->convertToPHPValue(null));
+    }
+
+    public function testConvertToPHPValueOnInvalidType(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->stringType->convertToPHPValue(1);
+    }
+
+    public function testConvertToPHPValueOnInvalidValue(): void
+    {
+        $this->expectException(ValueError::class);
+        $this->stringType->convertToPHPValue('invalid');
+    }
+}

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/TypesDumperTest.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/TypesDumperTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
  * @author Elao <contact@elao.com>
  */
 
-namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\DBAL\Types;
+namespace Elao\Enum\Tests\Unit\Bridge\Doctrine\ODM\Types;
 
 use Elao\Enum\Bridge\Doctrine\Common\AbstractTypesDumper;
-use Elao\Enum\Bridge\Doctrine\DBAL\Types\TypesDumper;
+use Elao\Enum\Bridge\Doctrine\ODM\Types\TypesDumper;
 use Elao\Enum\Tests\Unit\Bridge\Doctrine\Common\Types\BaseTypesDumperTest;
 
 class TypesDumperTest extends BaseTypesDumperTest
@@ -27,10 +27,9 @@ class TypesDumperTest extends BaseTypesDumperTest
     {
         return [
             ['Foo\Bar\Baz', 'single', 'Foo\Bar\Baz'],
-            ['Foo\Bar\BazWithDefault', 'single', 'baz_with_default', 'foo'],
             ['Foo\Bar\Qux', 'single', 'Foo\Bar\Qux'],
             ['Foo\Baz\Foo', 'single', 'foo'],
-            ['Foo\Baz\FooWithDefault', 'single', 'foo_with_default', 3],
+            ['Foo\Baz\Foo', 'collection', 'foo_collection'],
         ];
     }
 

--- a/tests/Unit/Bridge/Doctrine/ODM/Types/TypesDumperTest/dumped_types.php
+++ b/tests/Unit/Bridge/Doctrine/ODM/Types/TypesDumperTest/dumped_types.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ELAO_ENUM_DT_ODM\Foo\Bar {
+
+    if (!\class_exists(BazType::class)) {
+        class BazType extends \Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType
+        {
+            protected function getEnumClass(): string
+            {
+                return \Foo\Bar\Baz::class;
+            }
+        }
+    }
+
+    if (!\class_exists(QuxType::class)) {
+        class QuxType extends \Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType
+        {
+            protected function getEnumClass(): string
+            {
+                return \Foo\Bar\Qux::class;
+            }
+        }
+    }
+
+}
+
+namespace ELAO_ENUM_DT_ODM\Foo\Baz {
+
+    if (!\class_exists(FooType::class)) {
+        class FooType extends \Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractEnumType
+        {
+            protected function getEnumClass(): string
+            {
+                return \Foo\Baz\Foo::class;
+            }
+        }
+    }
+
+    if (!\class_exists(FooCollectionType::class)) {
+        class FooCollectionType extends \Elao\Enum\Bridge\Doctrine\ODM\Types\AbstractCollectionEnumType
+        {
+            protected function getEnumClass(): string
+            {
+                return \Foo\Baz\Foo::class;
+            }
+        }
+    }
+
+}

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPassTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/Compiler/DoctrineODMTypesPassTest.php
@@ -12,20 +12,20 @@ declare(strict_types=1);
 
 namespace Elao\Enum\Tests\Unit\Bridge\Symfony\Bundle\DependencyInjection\Compiler;
 
-use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineDBALTypesPass;
+use Elao\Enum\Bridge\Symfony\Bundle\DependencyInjection\Compiler\DoctrineODMTypesPass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class DoctrineDBALTypesPassTest extends TestCase
+class DoctrineODMTypesPassTest extends TestCase
 {
-    private readonly DoctrineDBALTypesPass $pass;
+    private readonly DoctrineODMTypesPass $pass;
 
     private readonly string $dumpPath;
 
     protected function setUp(): void
     {
         $this->dumpPath = sys_get_temp_dir() . '/elao_enum_types_dumper.php';
-        $this->pass = new DoctrineDBALTypesPass($this->dumpPath);
+        $this->pass = new DoctrineODMTypesPass($this->dumpPath);
     }
 
     protected function tearDown(): void
@@ -36,7 +36,7 @@ class DoctrineDBALTypesPassTest extends TestCase
     public function testDoesNothingOnNoTypesSet(): void
     {
         $container = new ContainerBuilder();
-        $def = $container->register('doctrine.dbal.connection_factory', \stdClass::class);
+        $def = $container->register('doctrine_mongodb.odm.manager_configurator.abstract', \stdClass::class);
 
         $this->pass->process($container);
 
@@ -47,10 +47,10 @@ class DoctrineDBALTypesPassTest extends TestCase
     public function testDumpsOnTypesSet(): void
     {
         $container = new ContainerBuilder();
-        $def = $container->register('doctrine.dbal.connection_factory', \stdClass::class);
-        $container->getParameterBag()->set('.elao_enum.doctrine_types', [
+        $def = $container->register('doctrine_mongodb.odm.manager_configurator.abstract', \stdClass::class);
+        $container->getParameterBag()->set('.elao_enum.doctrine_mongodb_types', [
             ['Foo\Bar\Baz', 'single', 'baz', null],
-            ['Foo\Bar\Qux', 'single', 'qux', null],
+            ['Foo\Bar\Qux', 'collection', 'qux', null],
         ]);
 
         $this->pass->process($container);

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtensionTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/ElaoEnumExtensionTest.php
@@ -37,9 +37,9 @@ abstract class ElaoEnumExtensionTest extends TestCase
         $container = $this->createContainerFromFile('doctrine_types');
 
         self::assertEquals([
-            [Suit::class, 'suit', null],
-            [Permissions::class, 'permissions', null],
-            [RequestStatus::class, 'request_status', 200],
+            [Suit::class, 'single', 'suit', null],
+            [Permissions::class, 'single', 'permissions', null],
+            [RequestStatus::class, 'single', 'request_status', 200],
         ], $container->getParameter('.elao_enum.doctrine_types'));
     }
 


### PR DESCRIPTION
Adding Doctrine ODM integration:

- [x] Add simple base type
- [x] Add collection base type
- [x] Add tests for base types
- [x] Add types dumper
- [x] Integrate with bundle
- [x] Add tests for the dumper
- [x] Add tests for the bundle integration

Most tests could be copied from the v1 and adjusted slightly.

Please note that I added `type` option for each Doctrine Type - for now, ORM will only support `single` as `collection` is not implemented yet.