### PR TITLE
add Faker provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,3 +437,60 @@ class Card
     private Suit $field;
 }
 ```
+
+### Faker
+
+The PhpEnums library provides a faker `EnumProvider` allowing to select random enum cases:
+
+```php
+use \Elao\Enum\Bridge\Faker\Provider\EnumProvider;
+ 
+$faker = new Faker\Generator();
+$faker->addProvider(new EnumProvider());
+
+$faker->randomEnum(Suit::class) // Select one of the Suit cases, e.g: `Suit::Hearts`
+$faker->randomEnums(Suit::class, 2, min: 1) // Select between 1 and 2 enums cases, e.g: `[Suit::Hearts, Suit::Spades]`
+$faker->randomEnums(Suit::class, 3, exact: true) // Select exactly 3 enums cases
+```
+
+Its constructor receives a mapping of enum types aliases as first argument:
+
+```php
+new EnumProvider([
+    'Civility' => App\Enum\Civility::class,
+    'Suit' => App\Enum\Suit::class,
+]);
+```
+
+This is especially useful when using this provider with Nelmio Alice's DSL (_see next section_)
+
+### Usage with Alice
+
+If you're using the [nelmio/alice](https://github.com/nelmio/alice) package and its bundle in order to generate fixtures, 
+you can register the Faker provider by using the `nelmio_alice.faker.generator`:
+
+```yml
+# config/services.yaml
+services:
+    Elao\Enum\Bridge\Faker\Provider\EnumProvider:
+        arguments:
+            - Civility: App\Enum\Civility
+              Suit: App\Enum\Suit
+        tags: ['nelmio_alice.faker.provider']
+```
+
+The following example shows how to use the provider within a [PHP fixture file](https://github.com/nelmio/alice/blob/master/doc/complete-reference.md#php):
+
+```php
+return [
+    MyEntity::class => [
+        'entity1' => [
+            'civility' => Civility::MISTER // Select a specific case, using PHP directly
+            'suit' => '<randomEnum(App\Enum\Suit)>' // Select a random case
+            'suit' => '<randomEnum(Suit)>' // Select a random case, using the FQCN alias
+            'permissions' => '<randomEnums(Permissions, 3, false, 1)>' // Select between 1 and 2 enums cases
+            'permissions' => '<randomEnums(Permissions, 3, true)>' // Select exactly 3 enums cases
+        ]
+    ]
+]
+```

--- a/src/Bridge/Faker/Provider/EnumProvider.php
+++ b/src/Bridge/Faker/Provider/EnumProvider.php
@@ -13,37 +13,77 @@ declare(strict_types=1);
 namespace Elao\Enum\Bridge\Faker\Provider;
 
 use Elao\Enum\Exception\InvalidArgumentException;
-use UnitEnum;
 
 class EnumProvider
 {
     /**
-     * @param array<string, class-string<UnitEnum>> $enumMapping
+     * @param array<string, class-string<\UnitEnum>> $aliases
      */
-    public function __construct(private array $enumMapping = [])
+    public function __construct(private array $aliases = [])
     {
-        foreach ($enumMapping as $enumClass) {
+        foreach ($aliases as $enumClass) {
             $this->ensureEnumClass($enumClass);
         }
     }
 
-    public function randomEnum(string $enumClassOrAlias): UnitEnum
+    /**
+     * Selects a random enum case.
+     */
+    public function randomEnum(string $enumClassOrAlias): \UnitEnum
     {
-        /** @var UnitEnum|string $class */
-        $class = $this->enumMapping[$enumClassOrAlias] ?? $enumClassOrAlias;
+        /** @var \UnitEnum|string $class */
+        $class = $this->aliases[$enumClassOrAlias] ?? $enumClassOrAlias;
+
         $this->ensureEnumClass($class);
 
-        $instances = $class::cases();
+        $cases = $class::cases();
 
-        return $instances[random_int(0, \count($instances) - 1)];
+        return $cases[mt_rand(0, \count($cases) - 1)];
     }
 
     /**
-     * @param class-string<UnitEnum> $enumClass
+     * Selects given number of enum cases, between $count & $min.
+     *
+     * @param int  $count The max nb of cases to select
+     * @param bool $exact If true, the exact $count of enums will be generated
+     *                    (unless there is no more unique value available)
+     * @param int  $min   The min nb of enums to generate, if not $exact
+     *
+     * @return \UnitEnum[]
+     */
+    public function randomEnums(string $enumClassOrAlias, int $count, bool $exact = false, int $min = 0): array
+    {
+        $selectedCases = [];
+
+        if (!$exact) {
+            $count = mt_rand($min, $count);
+        }
+
+        /** @var \UnitEnum|string $class */
+        $class = $this->aliases[$enumClassOrAlias] ?? $enumClassOrAlias;
+
+        $this->ensureEnumClass($class);
+
+        $cases = $class::cases();
+
+        while ($count > 0 && !empty($cases)) {
+            $randomRank = mt_rand(0, \count($cases) - 1);
+            $selectedCases[] = $cases[$randomRank];
+            unset($cases[$randomRank]);
+            $cases = array_values($cases);
+
+            --$count;
+        }
+
+        return $selectedCases;
+    }
+
+    /**
+     * @param class-string<\UnitEnum> $enumClass
      */
     private function ensureEnumClass(string $enumClass): void
     {
-        if (!is_a($enumClass, UnitEnum::class, true)) {
+        if (!is_a($enumClass, \UnitEnum::class, true)) {
             throw new InvalidArgumentException(sprintf('"%s" is not a proper enum class', $enumClass));
         }
     }

--- a/src/Bridge/Faker/Provider/EnumProvider.php
+++ b/src/Bridge/Faker/Provider/EnumProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Bridge\Faker\Provider;
+
+use Elao\Enum\Exception\InvalidArgumentException;
+use UnitEnum;
+
+class EnumProvider
+{
+    /**
+     * @param array<string, class-string<UnitEnum>> $enumMapping
+     */
+    public function __construct(private array $enumMapping = [])
+    {
+        foreach ($enumMapping as $enumClass) {
+            $this->ensureEnumClass($enumClass);
+        }
+    }
+
+    public function randomEnum(string $enumClassOrAlias): UnitEnum
+    {
+        /** @var UnitEnum|string $class */
+        $class = $this->enumMapping[$enumClassOrAlias] ?? $enumClassOrAlias;
+        $this->ensureEnumClass($class);
+
+        $instances = $class::cases();
+
+        return $instances[random_int(0, \count($instances) - 1)];
+    }
+
+    /**
+     * @param class-string<UnitEnum> $enumClass
+     */
+    private function ensureEnumClass(string $enumClass): void
+    {
+        if (!is_a($enumClass, UnitEnum::class, true)) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a proper enum class', $enumClass));
+        }
+    }
+}

--- a/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
+++ b/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit\Bridge\Faker\Provider;
+
+use DateTime;
+use Elao\Enum\Bridge\Faker\Provider\EnumProvider;
+use Elao\Enum\Exception\InvalidArgumentException;
+use Elao\Enum\Tests\Fixtures\Enum\Permissions;
+use Elao\Enum\Tests\Fixtures\Enum\Suit;
+use PHPUnit\Framework\TestCase;
+
+class EnumProviderTest extends TestCase
+{
+    public function testRandomEnumMethodShouldReturnExpectedEnums(): void
+    {
+        $enumProvider = $this->getDefaultProvider();
+
+        $simple = $enumProvider->randomEnum('Suit');
+        self::assertInstanceOf(Suit::class, $simple);
+
+        $gender = $enumProvider->randomEnum(Suit::class);
+        self::assertInstanceOf(Suit::class, $gender);
+
+        $permissions = $enumProvider->randomEnum('Permissions');
+        self::assertInstanceOf(Permissions::class, $permissions);
+    }
+
+    /**
+     * @dataProvider provideErroneousEnumMapping
+     */
+    public function testConstructorShouldFailWhenEnumClassIsIncorrect(array $mapping): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new EnumProvider($mapping);
+    }
+
+    public function provideErroneousEnumMapping(): iterable
+    {
+        yield 'EnumProvider constructor with a class that does not exist' => [[
+            'Suit' => Suit::class,
+            'Not-a-class' => '\UnexistingClass',
+        ]];
+
+        yield 'EnumProvider constructor with a class that is not an Enum' => [[
+            'Suit' => Suit::class,
+            'Not-an-enum' => DateTime::class,
+        ]];
+    }
+
+    private function getDefaultProvider(): EnumProvider
+    {
+        return new EnumProvider([
+            'Suit' => Suit::class,
+            'Permissions' => Permissions::class,
+        ]);
+    }
+}

--- a/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
+++ b/tests/Unit/Bridge/Faker/Provider/EnumProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Elao\Enum\Tests\Unit\Bridge\Faker\Provider;
 
-use DateTime;
 use Elao\Enum\Bridge\Faker\Provider\EnumProvider;
 use Elao\Enum\Exception\InvalidArgumentException;
 use Elao\Enum\Tests\Fixtures\Enum\Permissions;
@@ -35,6 +34,32 @@ class EnumProviderTest extends TestCase
         self::assertInstanceOf(Permissions::class, $permissions);
     }
 
+    public function testRandomEnums(): void
+    {
+        $enumProvider = $this->getDefaultProvider();
+        $nbCases = \count(Suit::cases());
+
+        // Test generating all values in random order (no duplicates)
+        $suits = $enumProvider->randomEnums(Suit::class, $nbCases, false);
+        self::assertEmpty(array_udiff(
+            $suits,
+            Suit::cases(),
+            static function ($a, $b) { return $a === $b ? 1 : 0; }
+        ), 'contains all unique enum cases');
+
+        $count = \count($enumProvider->randomEnums(Suit::class, $max = 1));
+        self::assertTrue($count >= 0, "at least $max variable nb of enum generated");
+
+        $count = \count($enumProvider->randomEnums(Suit::class, $max = 3, false, $min = 1));
+        self::assertTrue($count >= $min && $count <= $max, "variable nb of enum cases selected between $min and $max");
+
+        $count = \count($enumProvider->randomEnums(Suit::class, $max = 3, true));
+        self::assertSame($max, $count, "exactly $max nb of enum cases selected");
+
+        $count = \count($enumProvider->randomEnums(Suit::class, $nbCases + 1, true));
+        self::assertSame($count, $nbCases, 'won\'t exceed maximum nb of cases for the enum');
+    }
+
     /**
      * @dataProvider provideErroneousEnumMapping
      */
@@ -54,7 +79,7 @@ class EnumProviderTest extends TestCase
 
         yield 'EnumProvider constructor with a class that is not an Enum' => [[
             'Suit' => Suit::class,
-            'Not-an-enum' => DateTime::class,
+            'Not-an-enum' => \stdClass::class,
         ]];
     }
 


### PR DESCRIPTION
This PR adds simple Faker integration. Since `nelmio/alice` allows to use `<(My\Awesome\Suit::HEART)>` notation, there is no point for `enum()` generator but I think `randomEnum()` is still valid.

Registering the provider in v1 required some manual work in `services.yaml`. Do you think we could automate that with bundle configuration like this:

```yaml
elao_enum:
  nelmio_alice:
    aliases:
       Suit: App\Enums\Suit
       Permissions: App\Enums\Permissions
```

Would that make sense?