### PR TITLE
Add ExtrasInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ The `EnumCase` attributes also provides you a way to configure some extra attrib
 ```php
 namespace App\Enum;
 
-use Elao\Enum\ExtrasInterface;use Elao\Enum\ReadableEnumInterface;
+use Elao\Enum\ExtrasInterface;
+use Elao\Enum\ReadableEnumInterface;
 use Elao\Enum\ExtrasTrait;
 use Elao\Enum\Attribute\EnumCase;
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ The `EnumCase` attributes also provides you a way to configure some extra attrib
 ```php
 namespace App\Enum;
 
-use Elao\Enum\ReadableEnumInterface;
+use Elao\Enum\ExtrasInterface;use Elao\Enum\ReadableEnumInterface;
 use Elao\Enum\ExtrasTrait;
 use Elao\Enum\Attribute\EnumCase;
 
-enum Suit implements ReadableEnumInterface
+enum Suit implements ExtrasInterface
 {
     use ExtrasTrait;
 
@@ -167,7 +167,9 @@ Suit::Spades->getExtra('missing-key', true); // throws
 or create your own interfaces/traits:
 
 ```php
-interface RenderableEnumInterface 
+use Elao\Enum\ExtrasInterface;
+
+interface RenderableEnumInterface extends ExtrasInterface
 {
     public function getColor(): string;
     public function getIcon(): string;
@@ -204,6 +206,8 @@ enum Suit implements RenderableEnumInterface
 
 Suit::Hearts->getColor(); // 'red'
 ```
+
+Note that extras feature and [`ExtrasInterface`](src/ExtrasInterface.php) can be used as standalone without [`ReadableEnumInterface`](src/ReadableEnumInterface.php)  
 
 ## Flag enums
 

--- a/src/EnumCaseInterface.php
+++ b/src/EnumCaseInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum;
+
+interface EnumCaseInterface extends \UnitEnum
+{
+}

--- a/src/ExtrasInterface.php
+++ b/src/ExtrasInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum;
+
+interface ExtrasInterface extends \UnitEnum
+{
+    /**
+     * @throws \InvalidArgumentException if $throwOnMissingExtra is set to true
+     */
+    public function getExtra(string $key, bool $throwOnMissingExtra = false): mixed;
+
+    /**
+     * @return iterable<static, mixed>
+     */
+    public static function extras(string $key, bool $throwOnMissingExtra = false): iterable;
+}

--- a/src/ExtrasInterface.php
+++ b/src/ExtrasInterface.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Elao\Enum;
 
-interface ExtrasInterface extends \UnitEnum
+interface ExtrasInterface extends EnumCaseInterface
 {
     /**
      * @throws \InvalidArgumentException if $throwOnMissingExtra is set to true

--- a/src/ExtrasTrait.php
+++ b/src/ExtrasTrait.php
@@ -16,6 +16,9 @@ trait ExtrasTrait
 {
     use EnumCaseAttributesTrait;
 
+    /**
+     * {@inheritdoc}
+     */
     public function getExtra(string $key, bool $throwOnMissingExtra = false): mixed
     {
         if ($throwOnMissingExtra && !isset(static::arrayAccessibleExtras()[$this][$key])) {
@@ -31,7 +34,7 @@ trait ExtrasTrait
     }
 
     /**
-     * @return iterable<static, mixed>
+     * {@inheritdoc}
      */
     public static function extras(string $key, bool $throwOnMissingExtra = false): iterable
     {

--- a/src/ReadableEnumInterface.php
+++ b/src/ReadableEnumInterface.php
@@ -14,7 +14,7 @@ namespace Elao\Enum;
 
 use Elao\Enum\Exception\NameException;
 
-interface ReadableEnumInterface extends \UnitEnum
+interface ReadableEnumInterface extends EnumCaseInterface
 {
     /**
      * Gets human representations per enum cases.

--- a/tests/Fixtures/Enum/SuitWithExtras.php
+++ b/tests/Fixtures/Enum/SuitWithExtras.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 namespace Elao\Enum\Tests\Fixtures\Enum;
 
 use Elao\Enum\Attribute\EnumCase;
+use Elao\Enum\ExtrasInterface;
 use Elao\Enum\ExtrasTrait;
 
-enum SuitWithExtras
+enum SuitWithExtras implements ExtrasInterface
 {
     use ExtrasTrait;
 


### PR DESCRIPTION
This is useful as checking for trait support is quite hard and inefficient in PHP.

This allows you to use `is_a($some_enum, Elao\Enum\ExtrasInterface::class, true)` and `$some_enum instanceof Elao\Enum\ExtrasInterface::class` for enums that should support the `getExtra` method