### PR TITLE
Add PHPStan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,7 @@ jobs:
 
       - name: 'Run PHPUnit tests'
         run: vendor/bin/simple-phpunit --testdox --verbose ${{ matrix.code-coverage && '--coverage-text --coverage-clover build/logs/clover.xml' }}
+
+      - name: 'Run PHPStan'
+        run: vendor/bin/phpstan
+        if: ${{ matrix.mongodb }}

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,8 @@
         "doctrine/dbal": "^3.2",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.10",
+        "phpstan/phpstan": "^1.7",
+        "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/config": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4.2|^6.0.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,4 @@ parameters:
     checkGenericClassInNonGenericObjectType: false # https://phpstan.org/blog/generics-in-php-using-phpdocs
     reportUnmatchedIgnoredErrors: false
     checkMissingIterableValueType: false
+    treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+parameters:
+    level: 6
+    paths:
+        - src
+#        - tests
+    checkGenericClassInNonGenericObjectType: false # https://phpstan.org/blog/generics-in-php-using-phpdocs
+    reportUnmatchedIgnoredErrors: false
+    checkMissingIterableValueType: false

--- a/src/Attribute/EnumCase.php
+++ b/src/Attribute/EnumCase.php
@@ -15,6 +15,9 @@ namespace Elao\Enum\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS_CONSTANT)]
 class EnumCase
 {
+    /**
+     * @param array<string, mixed> $extras
+     */
     public function __construct(public readonly ?string $label = null, public readonly array $extras = [])
     {
     }

--- a/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
+++ b/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
@@ -14,9 +14,14 @@ namespace Elao\Enum\Bridge\Doctrine\Common;
 
 /**
  * @internal
+ *
+ * @phpstan-type Type = array{0: class-string<\BackedEnum>, 1: string, 2: string, 3: string|int|null}
  */
 abstract class AbstractTypesDumper
 {
+    /**
+     * @param Type[] $types
+     */
     public function dumpToFile(string $file, array $types): void
     {
         file_put_contents($file, $this->dump($types));
@@ -57,6 +62,9 @@ abstract class AbstractTypesDumper
         );
     }
 
+    /**
+     * @param Type[] $types
+     */
     private function dump(array $types): string
     {
         array_walk($types, static function (&$type) {
@@ -92,6 +100,9 @@ abstract class AbstractTypesDumper
 
     abstract protected function getTypeCode(string $classname, string $enumClass, string $type, string $name, \BackedEnum|int|string|null $defaultOnNull = null): string;
 
+    /**
+     * @return array<string, string>
+     */
     abstract protected static function getSuffixes(): array;
 
     abstract protected static function getMarker(): string;

--- a/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
+++ b/src/Bridge/Doctrine/Common/AbstractTypesDumper.php
@@ -17,7 +17,7 @@ namespace Elao\Enum\Bridge\Doctrine\Common;
  */
 abstract class AbstractTypesDumper
 {
-    public function dumpToFile(string $file, array $types)
+    public function dumpToFile(string $file, array $types): void
     {
         file_put_contents($file, $this->dump($types));
     }

--- a/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
+++ b/src/Bridge/Symfony/Bundle/ElaoEnumBundle.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ElaoEnumBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Bridge/Symfony/Form/Type/EnumType.php
+++ b/src/Bridge/Symfony/Form/Type/EnumType.php
@@ -25,7 +25,7 @@ class EnumType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             // Override the original type logic for label for readable enums.

--- a/src/Bridge/Symfony/Form/Type/FlagBagType.php
+++ b/src/Bridge/Symfony/Form/Type/FlagBagType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FlagBagType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!$options['multiple']) {
             throw new InvalidConfigurationException(sprintf(
@@ -38,7 +38,7 @@ class FlagBagType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefault('multiple', true)

--- a/src/Bridge/Symfony/VarDumper/Caster/FlagBagCaster.php
+++ b/src/Bridge/Symfony/VarDumper/Caster/FlagBagCaster.php
@@ -18,7 +18,7 @@ use Symfony\Component\VarDumper\Caster\ConstStub;
 
 final class FlagBagCaster
 {
-    public static function cast(FlagBag $bag)
+    public static function cast(FlagBag $bag): array
     {
         $a = [];
 

--- a/src/Bridge/Symfony/VarDumper/Caster/ReadableEnumCaster.php
+++ b/src/Bridge/Symfony/VarDumper/Caster/ReadableEnumCaster.php
@@ -17,7 +17,7 @@ use Symfony\Component\VarDumper\Caster\Caster;
 
 final class ReadableEnumCaster
 {
-    public static function cast(ReadableEnumInterface $enum, $array)
+    public static function cast(ReadableEnumInterface $enum, $array): array
     {
         return $array + [
             // Append the readable value;


### PR DESCRIPTION
This PR attempts to add PHPStan analysis to CI process.

Changes include:
- Using `phpunit/phpunit` to make it easier for PHPStan to discover its classes (`symfony/phpunit-bridge` no longer conflicts with it)
- Add some missing return types (this could potentially be a BC break if someone extends one of these classes and uses different return type)

To do:
- [ ] Add missing iterable types 
- [ ] Resolve templates issues (shadowing, etc)
- [ ] Add more missing types