### PR TITLE
[CI] Fix Github Actions deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             php: '8.1'
             symfony: '6.0.*@dev'
             allow-unstable: true
-            
+
           - name: 'Test Symfony 6.1 [Linux, PHP 8.1]'
             os: 'ubuntu-latest'
             php: '8.1'
@@ -94,7 +94,7 @@ jobs:
             allow-failure: true
             mysql: true
             mongodb: true
-            
+
           - name: 'Test next Symfony [Linux, PHP 8.2] (allowed failure)'
             os: 'ubuntu-latest'
             php: '8.2'
@@ -145,10 +145,10 @@ jobs:
 
       - name: 'Get composer cache directory'
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Cache dependencies'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}-flags-${{ matrix.composer-flags }}


### PR DESCRIPTION
Relates to:

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter