### PR TITLE
[Readable] Allow to configure a common suffix/prefix & use the enum case value/name as default label

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,15 @@ _Provides additional, opinionated features to the [PHP 8.1+ native enums](https:
 as specific integrations with frameworks and libraries._
 
 ```php
+#[ReadableEnum(prefix: 'suit.')]
 enum Suit: string implements ReadableEnumInterface
 {
     use ReadableEnumTrait;
 
-    #[EnumCase('suit.hearts')]
-    case Hearts = 'H';
-
-    #[EnumCase('suit.diamonds')]
-    case Diamonds = 'D';
-
-    #[EnumCase('suit.clubs')]
-    case Clubs = 'C';
-
-    #[EnumCase('suit.spades')]
-    case Spades = 'S';
+    case Hearts = '♥︎';
+    case Diamonds = '♦︎';
+    case Clubs = '♣︎';
+    case Spades = '︎♠︎';
 }
 ```
 
@@ -85,20 +79,20 @@ enum Suit: string implements ReadableEnumInterface
     use ReadableEnumTrait;
 
     #[EnumCase('suit.hearts')]
-    case Hearts = 'H';
+    case Hearts = '♥︎';
 
     #[EnumCase('suit.diamonds')]
-    case Diamonds = 'D';
+    case Diamonds = '♦︎';
 
     #[EnumCase('suit.clubs')]
-    case Clubs = 'C';
+    case Clubs = '♣︎';
 
     #[EnumCase('suit.spades')]
-    case Spades = 'S';
+    case Spades = '︎♠︎';
 }
 ```
 
-The following snippet shows how to get the human readable value of an enum:
+The following snippet shows how to get the human-readable value of an enum:
 
 ```php
 Suit::Hearts->getReadable(); // returns 'suit.hearts'
@@ -124,6 +118,46 @@ suit.spades: 'Trèfles'
 ```php
 $enum = Suit::Hearts;
 $translator->trans($enum->getReadable(), locale: 'fr'); // returns 'Coeurs'
+```
+
+### Configure suffix/prefix & default value
+
+As a shorcut, you can also use the [`ReadableEnum`](src/Attribute/ReadableEnum.php) attribute to define the
+common `suffix` and `prefix` to use, as well as defaulting on the enum case name or value, if not provided explicitly:
+
+```php
+#[ReadableEnum(prefix: 'suit.')]
+enum Suit: string implements ReadableEnumInterface
+{
+    use ReadableEnumTrait;
+
+    #[EnumCase('hearts︎')]
+    case Hearts = '♥︎';
+    case Diamonds = '♦︎';
+    case Clubs = '♣︎';
+    case Spades = '︎♠︎';
+}
+
+Suit::Hearts->getReadable(); // returns 'suit.hearts'
+Suit::Clubs->getReadable(); // returns 'suit.Clubs'
+```
+
+using the case value (only for string backed enums):
+
+```php
+#[ReadableEnum(prefix: 'suit.', useValueAsDefault: true)]
+enum Suit: string implements ReadableEnumInterface
+{
+    use ReadableEnumTrait;
+
+    case Hearts = 'hearts';
+    case Diamonds = 'diamonds';
+    case Clubs = 'clubs︎';
+    case Spades = '︎spades';
+}
+
+Suit::Hearts->getReadable(); // returns 'suit.hearts'
+Suit::Clubs->getReadable(); // returns 'suit.clubs'
 ```
 
 ## Extra values

--- a/src/Attribute/ReadableEnum.php
+++ b/src/Attribute/ReadableEnum.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Attribute;
+
+/**
+ * Autoconfigure a readable enum cases' labels, using the name or value + allow to configure a prefix and/or suffix for the key.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ReadableEnum
+{
+    public function __construct(
+        public readonly ?string $prefix = null,
+        public readonly ?string $suffix = null,
+        public readonly bool $useValueAsDefault = false
+    ) {
+    }
+}

--- a/tests/Unit/ReadableEnumAttributeTest.php
+++ b/tests/Unit/ReadableEnumAttributeTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "elao/enum" package.
+ *
+ * Copyright (C) Elao
+ *
+ * @author Elao <contact@elao.com>
+ */
+
+namespace Elao\Enum\Tests\Unit;
+
+use Elao\Enum\Attribute\EnumCase;
+use Elao\Enum\Attribute\ReadableEnum;
+use Elao\Enum\Exception\LogicException;
+use Elao\Enum\ReadableEnumInterface;
+use Elao\Enum\ReadableEnumTrait;
+use PHPUnit\Framework\TestCase;
+
+class ReadableEnumAttributeTest extends TestCase
+{
+    public function testReadableEnumAttribute(): void
+    {
+        self::assertSame(
+            'suit.Clubs.label',
+            ReadableAttributeSuit::readableForValue(ReadableAttributeSuit::Clubs->value),
+            'uses the name as default, with suffix and prefix',
+        );
+        self::assertSame(
+            'suit.hearts.label',
+            ReadableAttributeSuit::readableForValue(ReadableAttributeSuit::Hearts->value),
+            'uses the explicit label value, with suffix and prefix',
+        );
+    }
+
+    public function testReadableEnumAttributeWithoutSuffixPrefix(): void
+    {
+        self::assertSame(
+            'Clubs',
+            ReadableAttributeSuitWithoutSuffixPrefix::readableForValue(ReadableAttributeSuitWithoutSuffixPrefix::Clubs->value),
+            'uses the name as default, without any suffix or prefix',
+        );
+        self::assertSame(
+            'hearts',
+            ReadableAttributeSuitWithoutSuffixPrefix::readableForValue(ReadableAttributeSuitWithoutSuffixPrefix::Hearts->value),
+            'uses the explicit label value, without any suffix or prefix',
+        );
+    }
+
+    public function testReadableEnumAttributeWithValueAsDefault(): void
+    {
+        self::assertSame(
+            'suit.♣︎.label',
+            ReadableSuitAttributeWithValueAsDefault::readableForValue(ReadableSuitAttributeWithValueAsDefault::Clubs->value),
+            'uses the value as default, with suffix and prefix',
+        );
+        self::assertSame(
+            'suit.hearts.label',
+            ReadableSuitAttributeWithValueAsDefault::readableForValue(ReadableSuitAttributeWithValueAsDefault::Hearts->value),
+            'uses the explicit label value, with suffix and prefix',
+        );
+    }
+
+    public function testReadableEnumAttributeWithValueAsDefaultThrowsOnPureEnum(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot use "useValueAsDefault" with "#[Elao\Enum\Attribute\ReadableEnum]" attribute on enum "Elao\Enum\Tests\Unit\PureEnumWithReadableAttribute" as it\'s not a string backed enum.');
+
+        PureEnumWithReadableAttribute::Foo->getReadable();
+    }
+
+    public function testReadableEnumAttributeWithValueAsDefaultThrowsOnIntBackedEnum(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot use "useValueAsDefault" with "#[Elao\Enum\Attribute\ReadableEnum]" attribute on enum "Elao\Enum\Tests\Unit\IntBackedEnumWithReadableAttribute" as it\'s not a string backed enum.');
+
+        IntBackedEnumWithReadableAttribute::Foo->getReadable();
+    }
+}
+
+#[ReadableEnum(prefix: 'suit.', suffix: '.label')]
+enum ReadableAttributeSuit: string implements ReadableEnumInterface
+{
+    use ReadableEnumTrait;
+
+    #[EnumCase('hearts')]
+    case Hearts = '♥︎';
+
+    case Diamonds = '♦︎';
+    case Clubs = '♣︎';
+    case Spades = '︎♠︎';
+}
+
+#[ReadableEnum]
+enum ReadableAttributeSuitWithoutSuffixPrefix: string implements ReadableEnumInterface
+{
+    use ReadableEnumTrait;
+
+    #[EnumCase('hearts')]
+    case Hearts = '♥︎';
+
+    case Diamonds = '♦︎';
+    case Clubs = '♣︎';
+    case Spades = '︎♠︎';
+}
+
+#[ReadableEnum(prefix: 'suit.', suffix: '.label', useValueAsDefault: true)]
+enum ReadableSuitAttributeWithValueAsDefault: string implements ReadableEnumInterface
+{
+    use ReadableEnumTrait;
+
+    #[EnumCase('hearts')]
+    case Hearts = '♥︎';
+
+    case Diamonds = '♦︎';
+    case Clubs = '♣︎';
+    case Spades = '︎♠︎';
+}
+
+#[ReadableEnum(useValueAsDefault: true)]
+enum PureEnumWithReadableAttribute implements ReadableEnumInterface
+{
+    use ReadableEnumTrait;
+
+    case Foo;
+}
+
+#[ReadableEnum(useValueAsDefault: true)]
+enum IntBackedEnumWithReadableAttribute: int implements ReadableEnumInterface
+{
+    use ReadableEnumTrait;
+
+    case Foo = 1;
+}


### PR DESCRIPTION
Eases the declaration of readable enum translations keys with common suffix/prefix:

```php
#[ReadableEnum(prefix: 'suit.')]
enum Suit: string implements ReadableEnumInterface
{
    use ReadableEnumTrait;

    case Hearts = '♥︎';
    case Diamonds = '♦︎';
    case Clubs = '♣︎';
    case Spades = '︎♠︎';
}

Suit::Hearts->getReadable(); // returns 'suit.Hearts'
Suit::Clubs->getReadable(); // returns 'suit.Clubs'
```

[Docs](https://github.com/Elao/PhpEnums/blob/readable-auto/README.md#configure-suffixprefix--default-value)

## Questions

- Should we actually default on the `name` rather than the value by default when using this attribute?
- Name this attribute `ConfigureReadableEnum`? `AutoReadableEnum`?
- …