### PR TITLE
Removed unused bin reference in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
             "homepage": "https://github.com/ogizanagi"
         }
     ],
-    "bin": [
-        "bin/elao-enum-dump-js"
-    ],
     "autoload": {
         "psr-4": {
             "Elao\\Enum\\": "src/"


### PR DESCRIPTION
Fixes https://github.com/Elao/PhpEnums/issues/207

The script was removed in https://github.com/Elao/PhpEnums/releases/tag/v2.1.0 so the presence in composer.json triggers a warning.