### PR TITLE
Fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ An interface and a trait have been added for that purpose.
 use Elao\Enum\Bridge\Symfony\Translation\TranslatableEnumInterface;
 use Elao\Enum\Bridge\Symfony\Translation\TranslatableEnumTrait;
 
-class Card: string implements TranslatableEnumInterface
+enum Card: string implements TranslatableEnumInterface
 {
     use TranslatableEnumTrait;
     


### PR DESCRIPTION
This PR fixes a wrong code example in `README.md` where `class` was used instead of `enum`.