### PR TITLE
Add nullable type declaration for default null value

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -27,6 +27,7 @@ return (new PhpCsFixer\Config())
         'header_comment' => ['header' => $header],
         'native_function_invocation' => ['include' => ['@compiler_optimized']],
         'no_unneeded_final_method' => false, // final private __construct is a valid use-case
+        'nullable_type_declaration_for_default_null_value' => true,
         'ordered_imports' => true,
         'php_unit_namespaced' => true,
         'php_unit_method_casing' => false,

--- a/src/Bridge/Symfony/Translation/TranslatableEnumTrait.php
+++ b/src/Bridge/Symfony/Translation/TranslatableEnumTrait.php
@@ -19,7 +19,7 @@ trait TranslatableEnumTrait
 {
     use ReadableEnumTrait;
 
-    public function trans(TranslatorInterface $translator, string $locale = null): string
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
     {
         return $translator->trans($this->getReadable(), [], $locale);
     }


### PR DESCRIPTION
Fix depraction warning with PHP 8.4 and is compatible with [Symfony 5.4](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Contracts/Translation/TranslatableInterface.php)